### PR TITLE
feat(cli): add notification messages to configure wizard

### DIFF
--- a/cmd/hyprvoice/main.go
+++ b/cmd/hyprvoice/main.go
@@ -375,16 +375,12 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if t := strings.TrimSpace(scanner.Text()); t != "" {
 					cfg.Notifications.Messages.RecordingStarted.Title = t
-				} else {
-					cfg.Notifications.Messages.RecordingStarted.Title = recTitle
 				}
 			}
 			fmt.Printf("    Body (current: %s): ", recBody)
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.RecordingStarted.Body = b
-				} else {
-					cfg.Notifications.Messages.RecordingStarted.Body = recBody
 				}
 			}
 			fmt.Println()
@@ -395,16 +391,12 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if t := strings.TrimSpace(scanner.Text()); t != "" {
 					cfg.Notifications.Messages.Transcribing.Title = t
-				} else {
-					cfg.Notifications.Messages.Transcribing.Title = transTitle
 				}
 			}
 			fmt.Printf("    Body (current: %s): ", transBody)
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.Transcribing.Body = b
-				} else {
-					cfg.Notifications.Messages.Transcribing.Body = transBody
 				}
 			}
 			fmt.Println()
@@ -415,16 +407,12 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if t := strings.TrimSpace(scanner.Text()); t != "" {
 					cfg.Notifications.Messages.ConfigReloaded.Title = t
-				} else {
-					cfg.Notifications.Messages.ConfigReloaded.Title = reloadTitle
 				}
 			}
 			fmt.Printf("    Body (current: %s): ", reloadBody)
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.ConfigReloaded.Body = b
-				} else {
-					cfg.Notifications.Messages.ConfigReloaded.Body = reloadBody
 				}
 			}
 			fmt.Println()
@@ -435,16 +423,12 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if t := strings.TrimSpace(scanner.Text()); t != "" {
 					cfg.Notifications.Messages.OperationCancelled.Title = t
-				} else {
-					cfg.Notifications.Messages.OperationCancelled.Title = cancelTitle
 				}
 			}
 			fmt.Printf("    Body (current: %s): ", cancelBody)
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.OperationCancelled.Body = b
-				} else {
-					cfg.Notifications.Messages.OperationCancelled.Body = cancelBody
 				}
 			}
 			fmt.Println()
@@ -455,8 +439,6 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.RecordingAborted.Body = b
-				} else {
-					cfg.Notifications.Messages.RecordingAborted.Body = abortRecBody
 				}
 			}
 			fmt.Println()
@@ -467,8 +449,6 @@ func runInteractiveConfig() error {
 			if scanner.Scan() {
 				if b := strings.TrimSpace(scanner.Text()); b != "" {
 					cfg.Notifications.Messages.InjectionAborted.Body = b
-				} else {
-					cfg.Notifications.Messages.InjectionAborted.Body = abortInjBody
 				}
 			}
 		}
@@ -611,11 +591,6 @@ func saveConfig(cfg *config.Config) error {
   wtype_timeout = "%s"         # Timeout for wtype commands
   clipboard_timeout = "%s"     # Timeout for clipboard operations
 
-# Desktop Notification Configuration
-[notifications]
-  enabled = %v               # Enable desktop notifications
-  type = "%s"             # Notification type ("desktop", "log", "none")
-
 # Backend explanations:
 # - "ydotool": Uses ydotool (requires ydotoold daemon running). Most compatible with Chromium/Electron apps.
 # - "wtype": Uses wtype for Wayland. May have issues with some Chromium-based apps.
@@ -633,6 +608,11 @@ func saveConfig(cfg *config.Config) error {
 # Language codes: Use empty string ("") for automatic detection, or specific codes like:
 # "en" (English), "it" (Italian), "es" (Spanish), "fr" (French), "de" (German), etc.
 # For groq-translation, the language field hints at the source audio language for better accuracy.
+
+# Desktop Notification Configuration
+[notifications]
+  enabled = %v               # Enable desktop notifications
+  type = "%s"             # Notification type ("desktop", "log", "none")
 `,
 		cfg.Recording.SampleRate,
 		cfg.Recording.Channels,


### PR DESCRIPTION
## Summary

Adds the ability to customize notification messages through `hyprvoice configure` wizard (see #6).

- Prompts "Customize notification messages? [y/n]" (default: n)
- If yes, walks through all 6 notification types:
  - Recording Started (title + body)
  - Transcribing (title + body)
  - Config Reloaded (title + body)
  - Operation Cancelled (title + body)
  - Recording Aborted (body only)
  - Injection Aborted (body only)
- Only saves custom values (pressing Enter keeps defaults without writing them)
- Shows current values for each field

Builds on the `MessagesConfig` struct introduced in #5.

## Test plan

- [x] Run `hyprvoice configure`, say "y" to customize, enter custom values
- [x] Verify config file only contains custom values, not defaults
- [x] Verify `[notifications.messages]` section follows `[notifications]` directly
- [x] Run `go test ./...` - all tests pass

Closes #6

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Adds interactive wizard to customize notification messages through `hyprvoice configure`, building on the `MessagesConfig` struct from PR #5. The implementation intelligently saves only custom values to `config.toml` while displaying current/default values during configuration.

**Key Changes:**
- Added "Customize notification messages?" prompt with y/n input (defaults to n)
- Walks through 6 notification types: Recording Started, Transcribing, Config Reloaded, Operation Cancelled, Recording Aborted, and Injection Aborted
- Prompts for title and body (or body only for abort notifications)
- Empty input preserves defaults without writing them to config file
- `hasCustomMessages()` helper ensures `[notifications.messages]` section only written when needed
- Config section positioning moved to follow `[notifications]` directly
- Uses existing `Config.Get*()` methods to display current values

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- Implementation is clean, well-structured, and follows existing patterns. Only saves custom values (avoiding config bloat), proper error handling through scanner checks, integrates seamlessly with PR #5's foundation, and includes thorough testing per test plan.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| cmd/hyprvoice/main.go | Adds interactive configuration wizard for customizing notification messages - only saves custom values, preserving defaults |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ConfigWizard as Configure Wizard
    participant Config as Config Module
    participant FileSystem as File System

    User->>ConfigWizard: hyprvoice configure
    ConfigWizard->>Config: Load()
    Config->>FileSystem: Read config.toml
    FileSystem-->>Config: Existing config
    Config-->>ConfigWizard: Current config values
    
    ConfigWizard->>User: Customize notification messages? [y/n]
    User-->>ConfigWizard: yes
    
    loop For each notification type (6 total)
        ConfigWizard->>Config: Get[NotificationType]()
        Config-->>ConfigWizard: Current/default values
        ConfigWizard->>User: Show current: <value>
        User-->>ConfigWizard: Enter custom value or press Enter
        alt Custom value entered
            ConfigWizard->>Config: Set Messages.<Type>.<Field>
        else Empty input
            Note over ConfigWizard,Config: Keep default, don't set field
        end
    end
    
    ConfigWizard->>Config: Validate()
    Config-->>ConfigWizard: Validation result
    
    ConfigWizard->>FileSystem: saveConfig(cfg)
    Note over FileSystem: Write base config template
    FileSystem->>FileSystem: hasCustomMessages()?
    alt Has custom messages
        FileSystem->>FileSystem: Append [notifications.messages] section
        Note over FileSystem: Only writes non-empty fields
    end
    FileSystem-->>ConfigWizard: Config saved
    
    ConfigWizard->>User: ✅ Configuration saved successfully!
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->