### PR TITLE
add mistra voxtral

### DIFF
--- a/internal/transcriber/adapter_mistral.go
+++ b/internal/transcriber/adapter_mistral.go
@@ -1,0 +1,60 @@
+package transcriber
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/sashabaranov/go-openai"
+)
+
+// MistralAdapter implements TranscriptionAdapter for Mistral Voxtral API
+type MistralAdapter struct {
+	client *openai.Client
+	config Config
+}
+
+func NewMistralAdapter(config Config) *MistralAdapter {
+	clientConfig := openai.DefaultConfig(config.APIKey)
+	clientConfig.BaseURL = "https://api.mistral.ai/v1"
+	client := openai.NewClientWithConfig(clientConfig)
+
+	return &MistralAdapter{
+		client: client,
+		config: config,
+	}
+}
+
+func (a *MistralAdapter) Transcribe(ctx context.Context, audioData []byte) (string, error) {
+	if len(audioData) == 0 {
+		return "", nil
+	}
+
+	// Convert raw PCM to WAV format
+	wavData, err := convertToWAV(audioData)
+	if err != nil {
+		return "", fmt.Errorf("convert to WAV: %w", err)
+	}
+
+	// Create transcription request
+	req := openai.AudioRequest{
+		Model:    a.config.Model,
+		Reader:   bytes.NewReader(wavData),
+		FilePath: "audio.wav",
+		Language: a.config.Language,
+	}
+
+	start := time.Now()
+	resp, err := a.client.CreateTranscription(ctx, req)
+	duration := time.Since(start)
+
+	if err != nil {
+		log.Printf("mistral-adapter: API call failed after %v: %v", duration, err)
+		return "", fmt.Errorf("mistral transcription: %w", err)
+	}
+
+	log.Printf("mistral-adapter: transcribed %d bytes in %v: %q", len(audioData), duration, resp.Text)
+	return resp.Text, nil
+}

--- a/internal/transcriber/transcriber.go
+++ b/internal/transcriber/transcriber.go
@@ -51,6 +51,12 @@ func NewTranscriber(config Config) (Transcriber, error) {
 		}
 		adapter = NewGroqTranslationAdapter(config)
 
+	case "mistral-transcription":
+		if config.APIKey == "" {
+			return nil, fmt.Errorf("Mistral API key required")
+		}
+		adapter = NewMistralAdapter(config)
+
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", config.Provider)
 	}

--- a/internal/transcriber/transcriber_test.go
+++ b/internal/transcriber/transcriber_test.go
@@ -76,6 +76,26 @@ func TestNewTranscriber(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "valid mistral-transcription config",
+			config: Config{
+				Provider: "mistral-transcription",
+				APIKey:   "test-key",
+				Language: "de",
+				Model:    "voxtral-mini-latest",
+			},
+			wantErr: false,
+		},
+		{
+			name: "mistral-transcription config without api key",
+			config: Config{
+				Provider: "mistral-transcription",
+				APIKey:   "",
+				Language: "de",
+				Model:    "voxtral-mini-latest",
+			},
+			wantErr: true,
+		},
+		{
 			name: "unsupported provider",
 			config: Config{
 				Provider: "unsupported",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added Mistral Voxtral transcription provider (`mistral-transcription`) as a new option alongside OpenAI and Groq providers. This integration enables users to leverage Mistral's Voxtral models, which are optimized for European languages.

**Key Changes:**
- Created new `MistralAdapter` that reuses the OpenAI SDK client with custom base URL (`https://api.mistral.ai/v1`)
- Added configuration validation for Mistral models (`voxtral-mini-latest` and `voxtral-mini-2507`)
- Updated interactive configuration wizard to include Mistral as option 4
- Added `MISTRAL_API_KEY` environment variable support
- Extended test coverage to include Mistral provider cases
- Updated all documentation and comments to reference the new provider

The implementation follows the existing adapter pattern precisely, maintaining consistency with `GroqTranscriptionAdapter` and `OpenAIAdapter`.

<h3>Confidence Score: 5/5</h3>


- Safe to merge - well-structured feature addition with no breaking changes
- The implementation perfectly mirrors the existing adapter patterns (Groq and OpenAI), maintaining architectural consistency. All necessary validation, error handling, and configuration updates are present. Test coverage includes both success and error cases. No breaking changes to existing functionality.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/transcriber/adapter_mistral.go | New Mistral Voxtral adapter implementation following existing adapter patterns correctly |
| internal/transcriber/transcriber.go | Added mistral-transcription provider case with proper API key validation |
| internal/config/config.go | Added Mistral configuration validation, API key handling, and model validation |
| cmd/hyprvoice/main.go | Updated interactive configuration wizard with Mistral provider option and model selection |
| internal/transcriber/transcriber_test.go | Added test cases for Mistral provider with and without API key |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Config
    participant Transcriber
    participant MistralAdapter
    participant MistralAPI
    
    User->>Config: Select mistral-transcription provider
    Config->>Config: Validate MISTRAL_API_KEY
    Config->>Config: Validate model (voxtral-mini-latest/2507)
    Config->>Transcriber: NewTranscriber(config)
    Transcriber->>MistralAdapter: NewMistralAdapter(config)
    MistralAdapter->>MistralAdapter: Set BaseURL to api.mistral.ai/v1
    
    User->>Transcriber: Start recording
    Transcriber->>MistralAdapter: Transcribe(audioData)
    MistralAdapter->>MistralAdapter: convertToWAV(audioData)
    MistralAdapter->>MistralAPI: CreateTranscription(request)
    MistralAPI-->>MistralAdapter: Response with text
    MistralAdapter-->>Transcriber: Transcribed text
    Transcriber-->>User: Inject text to application
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->