### PR TITLE
fix: remove frame-stealing read from pipeline loop

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -196,8 +196,6 @@ func (p *pipeline) run(ctx context.Context) {
 
 	for {
 		select {
-		case <-frameCh:
-
 		case action := <-p.actionCh:
 			switch action {
 			case Inject:


### PR DESCRIPTION
## Summary

Fixes #20

- The pipeline main `select` loop was reading from `frameCh` alongside `SimpleTranscriber.collectAudio()`, causing both goroutines to race on the same channel
- In Go, each channel value goes to exactly one reader — so the pipeline was randomly consuming and discarding ~50% of audio frames
- This caused the transcriber to receive fragmented audio, producing incomplete transcriptions (e.g., a small sentence from the middle of a long speech)

## The Problem

```go
for {
    select {
    case <-frameCh:       // steals frames, discards them
    case action := <-p.actionCh:
        // ...
    case <-ctx.Done():
        return
    }
}
```

## Evidence

For an ~11 second recording at 16kHz/16-bit/mono (expected ~352,000 bytes), logs showed:

```
transcriber: transcribing 161052 bytes of audio
```

Only ~46% of audio data was reaching the transcriber.

## Fix

Remove `case <-frameCh:` from the pipeline select loop. The loop only needs to wait for actions (`actionCh`) and cancellation (`ctx.Done()`). All audio frames should be exclusively consumed by the transcriber.

## Environment

- **OS:** CachyOS (Arch-based)
- **Display server:** Wayland / Hyprland
- **Config:** `streaming = false`, `model = "gpt-4o-transcribe"`

## Testing

After removing the frame-stealing read, a full ~11 second recording produced the complete expected transcription with no missing segments.

Reported by: **Burak Gizlice**

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes a critical bug where the pipeline's main select loop was consuming audio frames from `frameCh`, causing a race condition with `SimpleTranscriber.collectAudio()`. In Go, each channel value goes to exactly one reader, so the pipeline was randomly stealing and discarding ~50% of audio frames (lines 198-199 removed). This resulted in incomplete transcriptions, with only ~46% of audio data reaching the transcriber.

- Removed the redundant `case <-frameCh:` from the select loop in `pipeline.run()` at internal/pipeline/pipeline.go:198-199
- The pipeline loop now only handles actions (`actionCh`) and cancellation (`ctx.Done()`), allowing all audio frames to be exclusively consumed by the transcriber
- Fix verified by testing: full ~11 second recording now produces complete transcription instead of fragmented output

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with high confidence
- The fix is minimal (2 lines removed), well-explained, and addresses a clear architectural bug. The removed code was consuming frames from a channel that should be exclusively read by the transcriber, causing ~50% data loss. The fix has been tested and verified to resolve the issue. No new code was added, eliminating risk of introducing new bugs.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/pipeline/pipeline.go | Removed redundant frame-stealing read from select loop, fixing audio data loss bug |

</details>



<sub>Last reviewed commit: 295bd0f</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->