### PR TITLE
feat: add injection success notification

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -95,6 +95,7 @@ type MessagesConfig struct {
 	OperationCancelled MessageConfig `toml:"operation_cancelled"`
 	RecordingAborted   MessageConfig `toml:"recording_aborted"`
 	InjectionAborted   MessageConfig `toml:"injection_aborted"`
+	InjectionComplete  MessageConfig `toml:"injection_complete"`
 }
 
 // Resolve merges user config with defaults from MessageDefs

--- a/internal/notify/message.go
+++ b/internal/notify/message.go
@@ -11,6 +11,7 @@ const (
 	MsgOperationCancelled
 	MsgRecordingAborted
 	MsgInjectionAborted
+	MsgInjectionComplete
 )
 
 // MessageDef defines a message type with its config key and defaults
@@ -31,6 +32,7 @@ var MessageDefs = []MessageDef{
 	{MsgOperationCancelled, "operation_cancelled", "Hyprvoice", "Operation Cancelled", false},
 	{MsgRecordingAborted, "recording_aborted", "", "Recording Aborted", true},
 	{MsgInjectionAborted, "injection_aborted", "", "Injection Aborted", true},
+	{MsgInjectionComplete, "injection_complete", "Hyprvoice", "Text Injected", false},
 }
 
 // Message is a resolved message ready for display

--- a/internal/notify/notify_test.go
+++ b/internal/notify/notify_test.go
@@ -13,6 +13,7 @@ func testMessages() map[MessageType]Message {
 		MsgOperationCancelled: {Title: "Hyprvoice", Body: "Operation Cancelled", IsError: false},
 		MsgRecordingAborted:   {Title: "", Body: "Recording Aborted", IsError: true},
 		MsgInjectionAborted:   {Title: "", Body: "Injection Aborted", IsError: true},
+		MsgInjectionComplete:  {Title: "Hyprvoice", Body: "Text Injected", IsError: false},
 	}
 }
 
@@ -105,8 +106,8 @@ func TestNotifierInterface(t *testing.T) {
 
 func TestMessageDefs(t *testing.T) {
 	// Verify MessageDefs contains expected entries
-	if len(MessageDefs) != 7 {
-		t.Errorf("Expected 7 MessageDefs, got %d", len(MessageDefs))
+	if len(MessageDefs) != 8 {
+		t.Errorf("Expected 8 MessageDefs, got %d", len(MessageDefs))
 	}
 
 	// Verify each has required fields

--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -339,6 +339,7 @@ func (p *pipeline) handleInjectAction(ctx context.Context, recorder recording.Re
 		p.sendError("Injection Error", "Failed to inject text", err)
 	} else {
 		log.Printf("Pipeline: Text injection completed successfully")
+		p.sendNotify(notify.MsgInjectionComplete)
 	}
 
 	p.setStatus(Idle)


### PR DESCRIPTION
## Summary

- Adds a `MsgInjectionComplete` notification that fires after text is successfully injected
- Users now get desktop/log confirmation that the pipeline completed ("Text Injected")
- Previously the pipeline only notified on errors or intermediate stages (recording started, transcribing, LLM processing) but had no success signal, leaving users uncertain whether injection actually happened
- Message is customizable via `[notifications.messages.injection_complete]` in the TOML config, consistent with all other notification messages

## Changes

- `internal/notify/message.go`: Add `MsgInjectionComplete` constant and `MessageDef` entry with default body "Text Injected"
- `internal/config/types.go`: Add `InjectionComplete` field to `MessagesConfig` for TOML customization
- `internal/pipeline/pipeline.go`: Send `MsgInjectionComplete` after successful `injector.Inject()`
- `internal/notify/notify_test.go`: Update test helper and `MessageDefs` count

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/notify/... ./internal/pipeline/... ./internal/config/...` all pass
- [ ] Manual test: run daemon, trigger recording + injection, verify desktop notification appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds success notification after text injection to provide user feedback when the pipeline completes successfully. Previously only error and intermediate states were notified.

**Key Changes:**
- New `MsgInjectionComplete` notification sent after successful `Inject()` call
- Configurable via `[notifications.messages.injection_complete]` in TOML config
- Default message: "Text Injected" with "Hyprvoice" title
- Follows existing notification pattern (constant → MessageDef → config binding)

**Issue Found:**
- `testMessages()` helper in `notify_test.go` was already incomplete (missing `MsgLLMProcessing`) and should include all message types for test coverage

<h3>Confidence Score: 4/5</h3>

- Safe to merge with one minor test improvement needed
- The implementation is clean, consistent with existing patterns, and properly integrated across all layers (constant, config, pipeline). One issue found: the test helper was already incomplete before this PR and should include all message types for proper test coverage.
- internal/notify/notify_test.go needs the missing `MsgLLMProcessing` entry added to `testMessages()` helper

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/notify/message.go | Adds `MsgInjectionComplete` constant and `MessageDef` entry with correct defaults |
| internal/config/types.go | Adds `InjectionComplete` field to `MessagesConfig` for TOML configuration support |
| internal/pipeline/pipeline.go | Sends `MsgInjectionComplete` notification after successful text injection |
| internal/notify/notify_test.go | Updates test helper and `MessageDefs` count, but test helper was already incomplete (missing `MsgLLMProcessing`) |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Pipeline
    participant Injector
    participant Notifier
    
    User->>Pipeline: Inject Action
    Pipeline->>Pipeline: Stop Recording & Transcribe
    alt LLM Enabled
        Pipeline->>Notifier: MsgLLMProcessing
        Pipeline->>Pipeline: Process with LLM
    end
    Pipeline->>Injector: Inject(text)
    alt Injection Success
        Injector-->>Pipeline: success
        Pipeline->>Notifier: MsgInjectionComplete ✨
        Pipeline->>Pipeline: setStatus(Idle)
    else Injection Failure
        Injector-->>Pipeline: error
        Pipeline->>Notifier: sendError("Injection Error")
        Pipeline->>Pipeline: setStatus(Idle)
    end
```

<sub>Last reviewed commit: 453a11c</sub>

<!-- greptile_other_comments_section -->

<sub>(5/5) You can turn off certain types of comments like style [here](https://app.greptile.com/review/github)!</sub>

<!-- /greptile_comment -->