### PR TITLE
fix: sanitize line-terminating characters during injection

### DIFF
--- a/internal/pipeline/pipeline.go
+++ b/internal/pipeline/pipeline.go
@@ -3,6 +3,7 @@ package pipeline
 import (
 	"context"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -330,6 +331,18 @@ func (p *pipeline) handleInjectAction(ctx context.Context, recorder recording.Re
 		}
 		p.setStatus(Injecting)
 	}
+
+	// Sanitize: replace line-terminating characters with spaces to prevent
+	// unintended Enter keypresses during injection, which can submit forms mid-sentence.
+	// Covers ASCII controls (\r, \n, \v, \f), Unicode NEL (U+0085),
+	// LINE SEPARATOR (U+2028), and PARAGRAPH SEPARATOR (U+2029).
+	textToInject = strings.Map(func(r rune) rune {
+		switch r {
+		case '\r', '\n', '\v', '\f', '\u0085', '\u2028', '\u2029':
+			return ' '
+		}
+		return r
+	}, textToInject)
 
 	injector := p.injectorFactory(p.config.ToInjectionConfig())
 


### PR DESCRIPTION
# fix: strip line-terminating characters before text injection

## Problem

Some STT providers occasionally include newline or other line-terminating characters in their transcript responses. When these are passed verbatim to `ydotool type` or `wtype`, they are simulated as actual keypresses. Meaning a `\n` becomes an Enter, which submits forms or creates new lines mid-sentence in input fields.

This is intermittent (depends on the provider and the specific audio input), but reproducible.

## Root cause

The pipeline passed `textToInject` straight to the injector with no sanitization, both after raw transcription and after optional LLM post-processing. The injection backends (`ydotool`, `wtype`) faithfully replay every character including line terminators as key events.

## Fix

Add a sanitization step in `handleInjectAction` (`internal/pipeline/pipeline.go`) immediately before the injector is called. Any line-terminating character is replaced with a space. This covers:

| Character | Code point | Name |
|-----------|------------|------|
| `\r\n` | U+000D U+000A | CRLF (Windows line endings) |
| `\r` | U+000D | Carriage Return |
| `\n` | U+000A | Line Feed |
| `\v` | U+000B | Vertical Tab |
| `\f` | U+000C | Form Feed |
| `\u0085` | U+0085 | NEXT LINE (NEL) |
| `\u2028` | U+2028 | LINE SEPARATOR |
| `\u2029` | U+2029 | PARAGRAPH SEPARATOR |

U+2028 and U+2029 are worth including explicitly: they are valid Unicode, can appear in JSON-decoded API responses, and browsers/Electron apps treat them as line breaks per the HTML spec.

## Change

Single file touched: `internal/pipeline/pipeline.go`

The fix runs after LLM post-processing so it also catches any newlines introduced by the LLM. The clipboard backend is unaffected in practice (newlines in clipboard content do not trigger keypresses).

All existing tests pass (`go test ./...`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds sanitization to prevent STT providers from accidentally submitting forms when transcripts contain newlines.

Key changes:
- Added `strings.Map` sanitization in `handleInjectAction` before text injection
- Replaces line-terminating characters (`\r`, `\n`, `\v`, `\f`, U+0085, U+2028, U+2029) with spaces
- Sanitization runs after LLM post-processing, so it catches newlines from both STT and LLM
- Positioned correctly in the pipeline: after all text transformations but before injection
- Clean implementation with comprehensive coverage of line terminators including Unicode variants

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no concerns
- The change is minimal (13 lines added), well-documented, correctly placed in the pipeline flow, and uses the appropriate standard library function (`strings.Map`). The sanitization covers all relevant line-terminating characters including rare Unicode variants, and the implementation correctly preserves all other characters. Existing tests pass and the fix addresses a real user-facing issue.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/pipeline/pipeline.go | Added sanitization to replace line-terminating characters with spaces before text injection, preventing unintended form submissions |

</details>



<sub>Last reviewed commit: b0fbe01</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->