### PR TITLE
document push-to-talk keybinding patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Run `hyprvoice configure` anytime for advanced settings.
 bind = SUPER, R, exec, hyprvoice toggle
 ```
 
-Each press toggles between recording and idle. If you experience issues with text injection (stuck keys, wrong characters), try `bindr` instead — it fires on key release, so modifiers like SUPER are fully released before the command runs.
+Each press toggles between recording and idle.
 
 ### Push-to-talk (hold-to-record)
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,10 @@ systemctl --user enable --now hyprvoice.service
 3. Add a keybinding (Hyprland example):
 
 ```bash
-bind = SUPER, R, exec, hyprvoice toggle
+bindr = SUPER, R, exec, hyprvoice toggle
 ```
+
+See [Hyprland Keybindings](#hyprland-keybindings) for push-to-talk and other patterns.
 
 4. Test voice input:
 
@@ -90,6 +92,38 @@ hyprvoice toggle
 ```
 
 Run `hyprvoice configure` anytime for advanced settings.
+
+## Hyprland Keybindings
+
+Hyprland has two bind types that matter for voice input:
+
+- **`bind`** — fires when the key is **pressed down**
+- **`bindr`** — fires when the key is **released**
+
+### Simple toggle (recommended default)
+
+```bash
+# ~/.config/hypr/hyprland.conf
+bindr = SUPER, R, exec, hyprvoice toggle
+```
+
+Using `bindr` (release) is important: modifiers like SUPER are fully released before `hyprvoice toggle` runs, so they don't interfere with text injection. With `bind`, the modifier may still be held when text is typed, causing stuck keys or wrong characters.
+
+### Push-to-talk (hold-to-record)
+
+Combine both bind types to get hold-to-record behavior — press to start, release to stop:
+
+```bash
+# ~/.config/hypr/hyprland.conf
+bind  = SUPER, R, exec, hyprvoice toggle   # key down → start recording
+bindr = SUPER, R, exec, hyprvoice toggle    # key up   → stop and transcribe
+```
+
+This gives a walkie-talkie feel: hold the key while speaking, release when done. The daemon receives two `toggle` commands — the first starts recording, the second stops it and triggers transcription.
+
+### Why `bindr` matters
+
+When you press SUPER+R with a regular `bind`, the SUPER modifier is still physically held when the command fires. If hyprvoice tries to inject text while SUPER is down, the compositor interprets the injected keystrokes as SUPER+key combos — leading to stuck modifiers, missed characters, or unexpected window management actions. `bindr` waits until you lift the key, ensuring a clean keyboard state for injection.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -95,11 +95,6 @@ Run `hyprvoice configure` anytime for advanced settings.
 
 ## Hyprland Keybindings
 
-Hyprland has two bind types that matter for voice input:
-
-- **`bind`** — fires when the key is **pressed down**
-- **`bindr`** — fires when the key is **released**
-
 ### Simple toggle
 
 ```bash
@@ -121,9 +116,14 @@ bindr = SUPER, R, exec, hyprvoice toggle    # key up   → stop and transcribe
 
 This gives a walkie-talkie feel: hold the key while speaking, release when done. The daemon receives two `toggle` commands — the first starts recording, the second stops it and triggers transcription.
 
-### Why `bindr` matters
+### `bind` vs `bindr`
 
-When you press SUPER+R with a regular `bind`, the SUPER modifier is still physically held when the command fires. If hyprvoice tries to inject text while SUPER is down, the compositor interprets the injected keystrokes as SUPER+key combos — leading to stuck modifiers, missed characters, or unexpected window management actions. `bindr` waits until you lift the key, ensuring a clean keyboard state for injection.
+| Keyword | Fires on |
+|---------|----------|
+| `bind` | Key **press** (down) |
+| `bindr` | Key **release** (up) |
+
+With `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This can prevent modifiers from interfering with text injection.
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ systemctl --user enable --now hyprvoice.service
 3. Add a keybinding (Hyprland example):
 
 ```bash
-bindr = SUPER, R, exec, hyprvoice toggle
+bind = SUPER, R, exec, hyprvoice toggle
 ```
 
 See [Hyprland Keybindings](#hyprland-keybindings) for push-to-talk and other patterns.
@@ -100,14 +100,14 @@ Hyprland has two bind types that matter for voice input:
 - **`bind`** — fires when the key is **pressed down**
 - **`bindr`** — fires when the key is **released**
 
-### Simple toggle (recommended default)
+### Simple toggle
 
 ```bash
 # ~/.config/hypr/hyprland.conf
-bindr = SUPER, R, exec, hyprvoice toggle
+bind = SUPER, R, exec, hyprvoice toggle
 ```
 
-Using `bindr` (release) is important: modifiers like SUPER are fully released before `hyprvoice toggle` runs, so they don't interfere with text injection. With `bind`, the modifier may still be held when text is typed, causing stuck keys or wrong characters.
+Each press toggles between recording and idle. If you experience issues with text injection (stuck keys, wrong characters), try `bindr` instead — it fires on key release, so modifiers like SUPER are fully released before the command runs.
 
 ### Push-to-talk (hold-to-record)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -48,7 +48,7 @@ Hyprvoice is triggered via Hyprland keybindings. The bind type you choose affect
 bind = SUPER, R, exec, hyprvoice toggle
 ```
 
-Each press toggles between recording and idle. If you run into issues with text injection (stuck keys, wrong characters), try `bindr` instead — it fires on key release so modifiers are guaranteed released before the command runs.
+Each press toggles between recording and idle.
 
 ### Push-to-talk (hold-to-record)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,6 +21,7 @@ Configuration is stored in `~/.config/hyprvoice/config.toml` and changes are app
 
 ## Table of Contents
 
+- [Hyprland Keybinding Patterns](#hyprland-keybinding-patterns)
 - [Unified Provider System](#unified-provider-system)
 - [Transcription Providers](#transcription-providers)
   - [Cloud Providers](#cloud-providers)
@@ -35,6 +36,48 @@ Configuration is stored in `~/.config/hyprvoice/config.toml` and changes are app
 - [Notifications](#notifications)
 - [Example Configurations](#example-configurations)
 - [Legacy Configs](#legacy-configs)
+
+## Hyprland Keybinding Patterns
+
+Hyprvoice is triggered via Hyprland keybindings. The bind type you choose affects reliability and workflow.
+
+### `bind` vs `bindr`
+
+| Keyword | Fires on | Use for |
+|---------|----------|---------|
+| `bind` | Key **press** (down) | Starting recording |
+| `bindr` | Key **release** (up) | Stopping recording / injecting text |
+
+The critical difference: with `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This prevents modifiers from interfering with text injection — avoiding stuck keys, wrong characters, or accidental compositor actions.
+
+### Simple toggle (recommended)
+
+A single `bindr` binding toggles recording on and off:
+
+```bash
+# ~/.config/hypr/hyprland.conf
+bindr = SUPER, R, exec, hyprvoice toggle
+```
+
+First release starts recording, second release stops and transcribes. This is the safest default because the keyboard is always in a clean state when text is injected.
+
+### Push-to-talk (hold-to-record)
+
+Pair `bind` (press) with `bindr` (release) on the same key for hold-to-record:
+
+```bash
+# ~/.config/hypr/hyprland.conf
+bind  = SUPER, R, exec, hyprvoice toggle   # key down → start recording
+bindr = SUPER, R, exec, hyprvoice toggle    # key up   → stop and transcribe
+```
+
+Hold the key while speaking, release when done. Both lines send `toggle` to the daemon — the first starts the pipeline, the second stops it. Because the stop fires on release, modifiers are clean for injection.
+
+### Why modifier release matters
+
+When SUPER+R is pressed with a regular `bind`, the SUPER key is still physically held when `hyprvoice toggle` fires. If hyprvoice then injects text (via wtype or ydotool), the compositor sees SUPER+<character> for every keystroke — triggering window management shortcuts instead of typing. Using `bindr` for the stop/inject side ensures modifiers are released first.
+
+This is especially relevant if you use the `wtype` or `ydotool` injection backends. The `clipboard` backend is less affected since it uses paste rather than simulated keystrokes, but `bindr` is still recommended for consistency.
 
 ## Unified Provider System
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,21 +45,19 @@ Hyprvoice is triggered via Hyprland keybindings. The bind type you choose affect
 
 | Keyword | Fires on | Use for |
 |---------|----------|---------|
-| `bind` | Key **press** (down) | Starting recording |
+| `bind` | Key **press** (down) | Simple toggle, starting recording |
 | `bindr` | Key **release** (up) | Stopping recording / injecting text |
 
-The critical difference: with `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This prevents modifiers from interfering with text injection — avoiding stuck keys, wrong characters, or accidental compositor actions.
+With `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This can prevent modifiers from interfering with text injection.
 
-### Simple toggle (recommended)
-
-A single `bindr` binding toggles recording on and off:
+### Simple toggle
 
 ```bash
 # ~/.config/hypr/hyprland.conf
-bindr = SUPER, R, exec, hyprvoice toggle
+bind = SUPER, R, exec, hyprvoice toggle
 ```
 
-First release starts recording, second release stops and transcribes. This is the safest default because the keyboard is always in a clean state when text is injected.
+Each press toggles between recording and idle. If you run into issues with text injection (stuck keys, wrong characters), try `bindr` instead — it fires on key release so modifiers are guaranteed released before the command runs.
 
 ### Push-to-talk (hold-to-record)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -41,15 +41,6 @@ Configuration is stored in `~/.config/hyprvoice/config.toml` and changes are app
 
 Hyprvoice is triggered via Hyprland keybindings. The bind type you choose affects reliability and workflow.
 
-### `bind` vs `bindr`
-
-| Keyword | Fires on | Use for |
-|---------|----------|---------|
-| `bind` | Key **press** (down) | Simple toggle, starting recording |
-| `bindr` | Key **release** (up) | Stopping recording / injecting text |
-
-With `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This can prevent modifiers from interfering with text injection.
-
 ### Simple toggle
 
 ```bash
@@ -71,11 +62,14 @@ bindr = SUPER, R, exec, hyprvoice toggle    # key up   → stop and transcribe
 
 Hold the key while speaking, release when done. Both lines send `toggle` to the daemon — the first starts the pipeline, the second stops it. Because the stop fires on release, modifiers are clean for injection.
 
-### Why modifier release matters
+### `bind` vs `bindr`
 
-When SUPER+R is pressed with a regular `bind`, the SUPER key is still physically held when `hyprvoice toggle` fires. If hyprvoice then injects text (via wtype or ydotool), the compositor sees SUPER+<character> for every keystroke — triggering window management shortcuts instead of typing. Using `bindr` for the stop/inject side ensures modifiers are released first.
+| Keyword | Fires on |
+|---------|----------|
+| `bind` | Key **press** (down) |
+| `bindr` | Key **release** (up) |
 
-This is especially relevant if you use the `wtype` or `ydotool` injection backends. The `clipboard` backend is less affected since it uses paste rather than simulated keystrokes, but `bindr` is still recommended for consistency.
+With `bindr`, modifier keys (SUPER, CTRL, etc.) are fully released before the command executes. This can prevent modifiers from interfering with text injection.
 
 ## Unified Provider System
 


### PR DESCRIPTION
## Summary

- adds a **Hyprland Keybindings** section to README.md explaining `bind` vs `bindr`, simple toggle, and push-to-talk (hold-to-record) patterns
- adds a **Hyprland Keybinding Patterns** section to docs/config.md with a reference table, examples for both workflows, and explanation of why modifier release matters for text injection
- updates the Quick Start example to use `bindr` (release-triggered) as the recommended default

relates to #22 (push-to-talk feature request) and #27 (stuck keyboard input)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Documentation-only PR that adds keybinding guidance for Hyprland users, addressing push-to-talk (issue #22) and stuck keyboard input (issue #27). Updates the Quick Start example from `bind` to `bindr` as the recommended default.

- Adds **Hyprland Keybindings** section to `README.md` covering `bind` vs `bindr`, simple toggle, and push-to-talk (hold-to-record) patterns
- Adds **Hyprland Keybinding Patterns** section to `docs/config.md` with a reference table, examples for both workflows, and explanation of why modifier release matters for text injection
- Updates Quick Start keybinding from `bind` to `bindr` to prevent modifier interference with `wtype`/`ydotool` injection backends
- Content is accurate and consistent with the daemon's toggle implementation and injection backend behavior verified in the codebase

<h3>Confidence Score: 5/5</h3>

- This is a documentation-only PR with no code changes — safe to merge with zero runtime risk.
- Pure documentation additions to README.md and docs/config.md. No code logic, configuration, or behavior changes. The documented keybinding patterns and injection backend descriptions were verified against the actual codebase (daemon toggle logic, pipeline state machine, injection backends). Content is accurate, well-structured, and addresses real user issues (#22, #27).
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| README.md | Adds Hyprland Keybindings section with bind vs bindr explanation, simple toggle, push-to-talk patterns, and updates Quick Start to use bindr. Content is accurate and consistent with the codebase. |
| docs/config.md | Adds Hyprland Keybinding Patterns section with reference table, toggle/push-to-talk examples, and modifier release explanation. Includes additional context about clipboard vs keystroke-based injection backends. Accurate and well-structured. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "Simple Toggle (bindr)"
        A1["User presses SUPER+R"] --> A2["User releases SUPER+R"]
        A2 -->|"bindr fires"| A3["hyprvoice toggle → Start Recording"]
        A3 --> A4["User presses SUPER+R again"]
        A4 --> A5["User releases SUPER+R"]
        A5 -->|"bindr fires"| A6["hyprvoice toggle → Stop & Transcribe"]
        A6 --> A7["Text injected (modifiers clean)"]
    end

    subgraph "Push-to-Talk (bind + bindr)"
        B1["User presses SUPER+R"] -->|"bind fires"| B2["hyprvoice toggle → Start Recording"]
        B2 --> B3["User holds key & speaks"]
        B3 --> B4["User releases SUPER+R"]
        B4 -->|"bindr fires"| B5["hyprvoice toggle → Stop & Transcribe"]
        B5 --> B6["Text injected (modifiers clean)"]
    end
```

<sub>Last reviewed commit: 6a64ba7</sub>

<!-- /greptile_comment -->