### PR TITLE
feat: add whisper-server provider for whisper.cpp HTTP server

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -157,7 +157,7 @@ language = ""                   # Empty for auto-detect
 
 ### Local Whisper HTTP Server (whisper-server)
 
-Use a locally-running OpenAI-compatible Whisper server such as [whisper.cpp server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) or [faster-whisper-server](https://github.com/fedirz/faster-whisper-server):
+Use [whisper.cpp server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) running locally. hyprvoice posts to the whisper.cpp native `/inference` endpoint — this is **not** OpenAI-compatible.
 
 ```toml
 [providers.whisper-server]
@@ -165,15 +165,13 @@ Use a locally-running OpenAI-compatible Whisper server such as [whisper.cpp serv
 
 [transcription]
   provider = "whisper-server"
-  model = "default"          # Sent to the server; whisper.cpp ignores it, faster-whisper-server uses it
+  model = "default"          # Sent as a form field; whisper.cpp ignores it (model is set at server startup)
   language = ""              # Empty for auto-detect
 ```
 
 **No API key required.** The `base_url` defaults to `http://localhost:8080` if not set.
 
-The `model` field is sent as a form field in the request. whisper.cpp ignores it (the model is chosen at server startup via `-m`). If you use faster-whisper-server or another server that routes by model name, set this to the model name your server expects.
-
-For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
+The `model` field is sent as a form field but whisper.cpp ignores it — the model is chosen at server startup via `-m`. For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
 
 ### Local Transcription (whisper-cpp)
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -155,6 +155,26 @@ language = ""                   # Empty for auto-detect
 - Nova-2: 33 languages, faster with filler word detection (batch+streaming)
 - Excellent for real-time transcription and live captions
 
+### Local Whisper HTTP Server (whisper-server)
+
+Use a locally-running OpenAI-compatible Whisper server such as [whisper.cpp server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) or [faster-whisper-server](https://github.com/fedirz/faster-whisper-server):
+
+```toml
+[providers.whisper-server]
+  base_url = "http://localhost:8080"  # URL of your running Whisper server
+
+[transcription]
+  provider = "whisper-server"
+  model = "whisper-1"        # Ignored by whisper.cpp; model is set at server startup
+  language = ""              # Empty for auto-detect
+```
+
+**No API key required.** The `base_url` defaults to `http://localhost:8080` if not set.
+
+The `model` field is sent to the server but whisper.cpp ignores it — the model is chosen at server startup via `-m`. Use `whisper-1` (the default) unless your server software requires a specific value.
+
+For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
+
 ### Local Transcription (whisper-cpp)
 
 Run Whisper models locally on your machine. No API keys, no network latency, complete privacy.
@@ -603,6 +623,23 @@ You can customize notification text via the `[notifications.messages]` section:
 
 [llm]
   enabled = false               # No LLM for full privacy
+```
+
+### Local Whisper Server
+
+```toml
+# No API keys needed!
+
+[providers.whisper-server]
+  base_url = "http://localhost:8080"
+
+[transcription]
+  provider = "whisper-server"
+  model = "whisper-1"           # Ignored by whisper.cpp; model is set at server startup
+  language = ""                 # Auto-detect
+
+[llm]
+  enabled = false
 ```
 
 ### Real-Time Streaming with Deepgram

--- a/docs/config.md
+++ b/docs/config.md
@@ -165,13 +165,13 @@ Use a locally-running OpenAI-compatible Whisper server such as [whisper.cpp serv
 
 [transcription]
   provider = "whisper-server"
-  model = "whisper-1"        # Ignored by whisper.cpp; model is set at server startup
+  model = "default"          # Sent to the server; whisper.cpp ignores it, faster-whisper-server uses it
   language = ""              # Empty for auto-detect
 ```
 
 **No API key required.** The `base_url` defaults to `http://localhost:8080` if not set.
 
-The `model` field is sent to the server but whisper.cpp ignores it — the model is chosen at server startup via `-m`. Use `whisper-1` (the default) unless your server software requires a specific value.
+The `model` field is sent as a form field in the request. whisper.cpp ignores it (the model is chosen at server startup via `-m`). If you use faster-whisper-server or another server that routes by model name, set this to the model name your server expects.
 
 For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
 
@@ -635,7 +635,7 @@ You can customize notification text via the `[notifications.messages]` section:
 
 [transcription]
   provider = "whisper-server"
-  model = "whisper-1"           # Ignored by whisper.cpp; model is set at server startup
+  model = "default"             # Sent to server; whisper.cpp ignores it, model is set at startup
   language = ""                 # Auto-detect
 
 [llm]

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -75,9 +75,9 @@ Streaming-first provider with Nova models. Excellent for real-time applications.
 
 ### whisper-server (Local HTTP Server)
 
-Run an OpenAI-compatible Whisper HTTP server locally and point hyprvoice at it. Supports [whisper.cpp server mode](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) and [faster-whisper-server](https://github.com/fedirz/faster-whisper-server).
+Run [whisper.cpp server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) locally and point hyprvoice at it. Uses whisper.cpp's native `/inference` endpoint — this is **not** OpenAI-compatible.
 
-The `model` field is sent as a form field in the request. whisper.cpp ignores it (the model is chosen at server startup via `-m`); use `default`. If you use faster-whisper-server or another server that routes by model name, set `transcription.model` to whatever name your server expects. For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
+The `model` field is sent as a form field in the request. whisper.cpp ignores it (the model is chosen at server startup via `-m`); use `default`. For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
 
 **Best for:** HTTP-based local transcription (e.g., shared server on LAN, GPU machine), or users who already run a Whisper server for other tools
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -12,6 +12,7 @@ This guide helps you choose the right transcription provider for your use case.
 | **ElevenLabs** | Cloud | 4 | 57+ | Yes | Fast | Excellent | Pay per use |
 | **Deepgram** | Cloud | 4 | 33-42 | Yes | Very Fast | Excellent | Pay per use |
 | **whisper-cpp** | Local | 12 | 57 (4 EN-only) | No | Varies | Excellent | Free |
+| **whisper-server** | Local | 3 | 57 | No | Varies | Excellent | Free |
 
 ### OpenAI
 
@@ -71,6 +72,16 @@ Streaming-first provider with Nova models. Excellent for real-time applications.
 **Language Support:** Nova-3 supports 42 languages, Nova-2 supports 33 languages. Not all 57 languages from the master list are available.
 
 **Best for:** Real-time transcription, live captions, meeting transcription
+
+### whisper-server (Local HTTP Server)
+
+Run an OpenAI-compatible Whisper HTTP server locally and point hyprvoice at it. Supports [whisper.cpp server mode](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) and [faster-whisper-server](https://github.com/fedirz/faster-whisper-server).
+
+The model is chosen at server startup (e.g. `whisper-server -m ggml-base.en.bin`). The `model` field in hyprvoice config is sent in the request but whisper.cpp ignores it — use `whisper-1`. For model downloads and setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
+
+**Best for:** HTTP-based local transcription (e.g., shared server on LAN, GPU machine), or users who already run a Whisper server for other tools
+
+---
 
 ### whisper-cpp (Local)
 

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -77,7 +77,7 @@ Streaming-first provider with Nova models. Excellent for real-time applications.
 
 Run an OpenAI-compatible Whisper HTTP server locally and point hyprvoice at it. Supports [whisper.cpp server mode](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) and [faster-whisper-server](https://github.com/fedirz/faster-whisper-server).
 
-The model is chosen at server startup (e.g. `whisper-server -m ggml-base.en.bin`). The `model` field in hyprvoice config is sent in the request but whisper.cpp ignores it — use `whisper-1`. For model downloads and setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
+The `model` field is sent as a form field in the request. whisper.cpp ignores it (the model is chosen at server startup via `-m`); use `default`. If you use faster-whisper-server or another server that routes by model name, set `transcription.model` to whatever name your server expects. For model downloads and server setup, see the [whisper.cpp README](https://github.com/ggml-org/whisper.cpp).
 
 **Best for:** HTTP-based local transcription (e.g., shared server on LAN, GPU machine), or users who already run a Whisper server for other tools
 

--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -32,8 +32,20 @@ func (c *Config) ToTranscriberConfig() transcriber.Config {
 	}
 
 	config.APIKey = c.resolveAPIKeyForProvider(c.Transcription.Provider)
+	config.BaseURL = c.resolveBaseURLForProvider(c.Transcription.Provider)
 
 	return config
+}
+
+// resolveBaseURLForProvider returns the base_url override for a provider from config
+func (c *Config) resolveBaseURLForProvider(providerName string) string {
+	baseName := provider.BaseProviderName(providerName)
+	if c.Providers != nil {
+		if pc, ok := c.Providers[baseName]; ok {
+			return pc.BaseURL
+		}
+	}
+	return ""
 }
 
 // resolveEffectiveLanguage returns the language for transcription

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -23,9 +23,10 @@ type Config struct {
 	LLM           LLMConfig                 `toml:"llm"`
 }
 
-// ProviderConfig holds API key for a provider
+// ProviderConfig holds API key and optional endpoint override for a provider
 type ProviderConfig struct {
-	APIKey string `toml:"api_key"`
+	APIKey  string `toml:"api_key"`
+	BaseURL string `toml:"base_url"`
 }
 
 // LLMConfig configures the LLM post-processing phase

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/leonardotrapani/hyprvoice/internal/provider"
@@ -80,6 +81,14 @@ func (c *Config) Validate() error {
 			envVar := envVarForProvider(registryName)
 			return fmt.Errorf("%s API key required: not found in config (providers.%s.api_key) or environment variable (%s)",
 				strings.Title(registryName), registryName, envVar)
+		}
+	}
+
+	// validate base_url if set
+	if baseURL := c.resolveBaseURLForProvider(c.Transcription.Provider); baseURL != "" {
+		u, err := url.Parse(baseURL)
+		if err != nil || (u.Scheme != "http" && u.Scheme != "https") || u.Host == "" {
+			return fmt.Errorf("invalid providers.%s.base_url %q: must be a valid http/https URL (e.g., \"http://localhost:8080\")", registryName, baseURL)
 		}
 	}
 

--- a/internal/provider/names.go
+++ b/internal/provider/names.go
@@ -2,12 +2,13 @@ package provider
 
 // Provider name constants for config and registry
 const (
-	ProviderOpenAI     = "openai"
-	ProviderGroq       = "groq"
-	ProviderMistral    = "mistral"
-	ProviderElevenLabs = "elevenlabs"
-	ProviderDeepgram   = "deepgram"
-	ProviderWhisperCpp = "whisper-cpp"
+	ProviderOpenAI        = "openai"
+	ProviderGroq          = "groq"
+	ProviderMistral       = "mistral"
+	ProviderElevenLabs    = "elevenlabs"
+	ProviderDeepgram      = "deepgram"
+	ProviderWhisperCpp    = "whisper-cpp"
+	ProviderWhisperServer = "whisper-server"
 )
 
 // Config provider names (used in config file transcription.provider)
@@ -18,6 +19,7 @@ const (
 	ConfigProviderElevenLabs           = "elevenlabs"
 	ConfigProviderDeepgram             = "deepgram"
 	ConfigProviderWhisperCpp           = "whisper-cpp"
+	ConfigProviderWhisperServer        = "whisper-server"
 )
 
 // Environment variable names for API keys
@@ -37,6 +39,7 @@ const (
 	AdapterDeepgram         = "deepgram"
 	AdapterWhisperCpp       = "whisper-cpp"
 	AdapterOpenAIRealtime   = "openai-realtime"
+	AdapterWhisperServer    = "whisper-server"
 )
 
 // BaseProviderName maps config provider names to registry provider names

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,7 @@ func init() {
 	Register(&MistralProvider{})
 	Register(&ElevenLabsProvider{})
 	Register(&WhisperCppProvider{})
+	Register(&WhisperServerProvider{})
 	Register(&DeepgramProvider{})
 }
 

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -188,16 +188,16 @@ func TestModelsOfType(t *testing.T) {
 }
 
 func TestFindModelByID(t *testing.T) {
-	// find model that exists
-	m, p, err := FindModelByID("whisper-1")
+	// find model that exists in exactly one provider
+	m, p, err := FindModelByID("gpt-4o-transcribe")
 	if err != nil {
-		t.Errorf("FindModelByID('whisper-1') unexpected error: %v", err)
+		t.Errorf("FindModelByID('gpt-4o-transcribe') unexpected error: %v", err)
 	}
 	if m == nil || p == nil {
 		t.Fatal("FindModelByID returned nil")
 	}
-	if m.ID != "whisper-1" {
-		t.Errorf("FindModelByID returned model %q, want 'whisper-1'", m.ID)
+	if m.ID != "gpt-4o-transcribe" {
+		t.Errorf("FindModelByID returned model %q, want 'gpt-4o-transcribe'", m.ID)
 	}
 	if p.Name() != "openai" {
 		t.Errorf("FindModelByID returned provider %q, want 'openai'", p.Name())

--- a/internal/provider/whisper_server.go
+++ b/internal/provider/whisper_server.go
@@ -1,0 +1,81 @@
+package provider
+
+// WhisperServerProvider implements Provider for a local whisper.cpp HTTP server
+// using the native /inference endpoint
+type WhisperServerProvider struct{}
+
+func (p *WhisperServerProvider) Name() string {
+	return ProviderWhisperServer
+}
+
+func (p *WhisperServerProvider) RequiresAPIKey() bool {
+	return false
+}
+
+func (p *WhisperServerProvider) ValidateAPIKey(key string) bool {
+	return true // API key is optional for local servers
+}
+
+func (p *WhisperServerProvider) APIKeyURL() string {
+	return ""
+}
+
+func (p *WhisperServerProvider) IsLocal() bool {
+	return true
+}
+
+func (p *WhisperServerProvider) Models() []Model {
+	allLangs := whisperTranscriptionLanguages
+	docsURL := "https://github.com/ggml-org/whisper.cpp/tree/master/examples/server"
+	defaultEndpoint := &EndpointConfig{BaseURL: "http://localhost:8080", Path: "/inference"}
+
+	return []Model{
+		{
+			ID:                 "whisper-1",
+			Name:               "Whisper 1",
+			Description:        "Default; model is selected by the server at startup",
+			Type:               Transcription,
+			SupportsBatch:      true,
+			SupportsStreaming:  false,
+			Local:              true,
+			AdapterType:        AdapterWhisperServer,
+			SupportedLanguages: allLangs,
+			Endpoint:           defaultEndpoint,
+			DocsURL:            docsURL,
+		},
+		{
+			ID:                 "whisper-large-v3",
+			Name:               "Whisper Large v3",
+			Description:        "Best accuracy; use with a server loaded with the large-v3 model",
+			Type:               Transcription,
+			SupportsBatch:      true,
+			SupportsStreaming:  false,
+			Local:              true,
+			AdapterType:        AdapterWhisperServer,
+			SupportedLanguages: allLangs,
+			Endpoint:           defaultEndpoint,
+			DocsURL:            docsURL,
+		},
+		{
+			ID:                 "whisper-large-v3-turbo",
+			Name:               "Whisper Large v3 Turbo",
+			Description:        "Near-best accuracy with better speed; use with a server loaded with the large-v3-turbo model",
+			Type:               Transcription,
+			SupportsBatch:      true,
+			SupportsStreaming:  false,
+			Local:              true,
+			AdapterType:        AdapterWhisperServer,
+			SupportedLanguages: allLangs,
+			Endpoint:           defaultEndpoint,
+			DocsURL:            docsURL,
+		},
+	}
+}
+
+func (p *WhisperServerProvider) DefaultModel(t ModelType) string {
+	switch t {
+	case Transcription:
+		return "whisper-1" // placeholder; whisper.cpp server ignores the model field — model is chosen at startup
+	}
+	return ""
+}

--- a/internal/provider/whisper_server.go
+++ b/internal/provider/whisper_server.go
@@ -31,35 +31,13 @@ func (p *WhisperServerProvider) Models() []Model {
 
 	return []Model{
 		{
-			ID:                 "whisper-1",
-			Name:               "Whisper 1",
-			Description:        "Default; model is selected by the server at startup",
-			Type:               Transcription,
-			SupportsBatch:      true,
-			SupportsStreaming:  false,
-			Local:              true,
-			AdapterType:        AdapterWhisperServer,
-			SupportedLanguages: allLangs,
-			Endpoint:           defaultEndpoint,
-			DocsURL:            docsURL,
-		},
-		{
-			ID:                 "whisper-large-v3",
-			Name:               "Whisper Large v3",
-			Description:        "Best accuracy; use with a server loaded with the large-v3 model",
-			Type:               Transcription,
-			SupportsBatch:      true,
-			SupportsStreaming:  false,
-			Local:              true,
-			AdapterType:        AdapterWhisperServer,
-			SupportedLanguages: allLangs,
-			Endpoint:           defaultEndpoint,
-			DocsURL:            docsURL,
-		},
-		{
-			ID:                 "whisper-large-v3-turbo",
-			Name:               "Whisper Large v3 Turbo",
-			Description:        "Near-best accuracy with better speed; use with a server loaded with the large-v3-turbo model",
+			// "default" is sent as the model field in the multipart request.
+			// whisper.cpp server ignores it — the model is chosen at startup via -m.
+			// Servers that do use the model field (e.g. faster-whisper-server) will
+			// need to set transcription.model to a value their server recognises.
+			ID:                 "default",
+			Name:               "Default",
+			Description:        "Uses whichever model the server was started with",
 			Type:               Transcription,
 			SupportsBatch:      true,
 			SupportsStreaming:  false,
@@ -75,7 +53,7 @@ func (p *WhisperServerProvider) Models() []Model {
 func (p *WhisperServerProvider) DefaultModel(t ModelType) string {
 	switch t {
 	case Transcription:
-		return "whisper-1" // placeholder; whisper.cpp server ignores the model field — model is chosen at startup
+		return "default"
 	}
 	return ""
 }

--- a/internal/transcriber/adapter_whisper_server.go
+++ b/internal/transcriber/adapter_whisper_server.go
@@ -19,12 +19,14 @@ import (
 // using its native /inference endpoint (multipart/form-data)
 type WhisperServerAdapter struct {
 	endpoint *provider.EndpointConfig
+	model    string
 	language string
 }
 
-func NewWhisperServerAdapter(endpoint *provider.EndpointConfig, language string) *WhisperServerAdapter {
+func NewWhisperServerAdapter(endpoint *provider.EndpointConfig, model, language string) *WhisperServerAdapter {
 	return &WhisperServerAdapter{
 		endpoint: endpoint,
+		model:    model,
 		language: language,
 	}
 }
@@ -32,6 +34,8 @@ func NewWhisperServerAdapter(endpoint *provider.EndpointConfig, language string)
 type whisperServerResponse struct {
 	Text string `json:"text"`
 }
+
+var whisperServerHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 func (a *WhisperServerAdapter) Transcribe(ctx context.Context, audioData []byte) (string, error) {
 	if len(audioData) == 0 {
@@ -58,13 +62,16 @@ func (a *WhisperServerAdapter) Transcribe(ctx context.Context, audioData []byte)
 	_ = w.WriteField("response_format", "json")
 	_ = w.WriteField("temperature", "0.0")
 
+	if a.model != "" {
+		_ = w.WriteField("model", a.model)
+	}
 	if a.language != "" {
 		_ = w.WriteField("language", a.language)
 	}
 
 	w.Close()
 
-	url := a.endpoint.BaseURL + a.endpoint.Path
+	url := strings.TrimRight(a.endpoint.BaseURL, "/") + a.endpoint.Path
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &body)
 	if err != nil {
 		return "", fmt.Errorf("create request: %w", err)
@@ -72,7 +79,7 @@ func (a *WhisperServerAdapter) Transcribe(ctx context.Context, audioData []byte)
 	req.Header.Set("Content-Type", w.FormDataContentType())
 
 	start := time.Now()
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := whisperServerHTTPClient.Do(req)
 	duration := time.Since(start)
 	if err != nil {
 		return "", fmt.Errorf("whisper-server request: %w", err)

--- a/internal/transcriber/adapter_whisper_server.go
+++ b/internal/transcriber/adapter_whisper_server.go
@@ -1,0 +1,109 @@
+package transcriber
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"mime/multipart"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/leonardotrapani/hyprvoice/internal/provider"
+)
+
+// WhisperServerAdapter implements BatchAdapter for the whisper.cpp HTTP server
+// using its native /inference endpoint (multipart/form-data)
+type WhisperServerAdapter struct {
+	endpoint *provider.EndpointConfig
+	language string
+}
+
+func NewWhisperServerAdapter(endpoint *provider.EndpointConfig, language string) *WhisperServerAdapter {
+	return &WhisperServerAdapter{
+		endpoint: endpoint,
+		language: language,
+	}
+}
+
+type whisperServerResponse struct {
+	Text string `json:"text"`
+}
+
+func (a *WhisperServerAdapter) Transcribe(ctx context.Context, audioData []byte) (string, error) {
+	if len(audioData) == 0 {
+		return "", nil
+	}
+
+	wavData, err := convertToWAV(audioData)
+	if err != nil {
+		return "", fmt.Errorf("convert to WAV: %w", err)
+	}
+
+	// build multipart body
+	var body bytes.Buffer
+	w := multipart.NewWriter(&body)
+
+	part, err := w.CreateFormFile("file", "audio.wav")
+	if err != nil {
+		return "", fmt.Errorf("create form file: %w", err)
+	}
+	if _, err := part.Write(wavData); err != nil {
+		return "", fmt.Errorf("write audio data: %w", err)
+	}
+
+	_ = w.WriteField("response_format", "json")
+	_ = w.WriteField("temperature", "0.0")
+
+	if a.language != "" {
+		_ = w.WriteField("language", a.language)
+	}
+
+	w.Close()
+
+	url := a.endpoint.BaseURL + a.endpoint.Path
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, &body)
+	if err != nil {
+		return "", fmt.Errorf("create request: %w", err)
+	}
+	req.Header.Set("Content-Type", w.FormDataContentType())
+
+	start := time.Now()
+	resp, err := http.DefaultClient.Do(req)
+	duration := time.Since(start)
+	if err != nil {
+		return "", fmt.Errorf("whisper-server request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("whisper-server error, status code: %d, body: %s", resp.StatusCode, string(respBody))
+	}
+
+	// whisper.cpp server may return one JSON object per segment on separate lines
+	var parts []string
+	dec := json.NewDecoder(bytes.NewReader(respBody))
+	for {
+		var result whisperServerResponse
+		if err := dec.Decode(&result); err == io.EOF {
+			break
+		} else if err != nil {
+			return "", fmt.Errorf("parse response: %w (body: %s)", err, string(respBody))
+		}
+		if t := strings.TrimSpace(result.Text); t != "" {
+			parts = append(parts, t)
+		}
+	}
+
+	text := strings.Join(parts, " ")
+	log.Printf("whisper-server: transcribed %d bytes in %v: %q", len(audioData), duration, text)
+	return text, nil
+}

--- a/internal/transcriber/transcriber.go
+++ b/internal/transcriber/transcriber.go
@@ -130,7 +130,7 @@ func NewTranscriber(config Config) (Transcriber, error) {
 	case provider.AdapterOpenAI:
 		adapter = NewOpenAIAdapter(batchEndpoint, config.APIKey, model.ID, config.Language, config.Keywords, registryProvider)
 	case provider.AdapterWhisperServer:
-		adapter = NewWhisperServerAdapter(batchEndpoint, config.Language)
+		adapter = NewWhisperServerAdapter(batchEndpoint, config.Model, config.Language)
 	case provider.AdapterElevenLabs:
 		adapter = NewElevenLabsAdapter(model.Endpoint, config.APIKey, model.ID, config.Language, config.Keywords)
 	case provider.AdapterDeepgram:

--- a/internal/transcriber/transcriber.go
+++ b/internal/transcriber/transcriber.go
@@ -31,8 +31,9 @@ type Config struct {
 	Language  string
 	Model     string
 	Keywords  []string
-	Threads   int  // CPU threads for local transcription (0 = auto)
-	Streaming bool // use streaming mode if model supports it
+	Threads   int    // CPU threads for local transcription (0 = auto)
+	Streaming bool   // use streaming mode if model supports it
+	BaseURL   string // override the provider's default endpoint base URL (e.g., "http://localhost:8080")
 }
 
 // NewTranscriber creates a new transcriber based on model metadata
@@ -117,11 +118,19 @@ func NewTranscriber(config Config) (Transcriber, error) {
 		return NewStreamingTranscriber(streamingAdapter, config.Language), nil
 	}
 
+	// resolve effective endpoint, allowing BaseURL override from config
+	batchEndpoint := model.Endpoint
+	if config.BaseURL != "" && batchEndpoint != nil {
+		batchEndpoint = &provider.EndpointConfig{BaseURL: config.BaseURL, Path: batchEndpoint.Path}
+	}
+
 	// batch mode: use SimpleTranscriber
 	var adapter BatchAdapter
 	switch model.AdapterType {
 	case provider.AdapterOpenAI:
-		adapter = NewOpenAIAdapter(model.Endpoint, config.APIKey, model.ID, config.Language, config.Keywords, registryProvider)
+		adapter = NewOpenAIAdapter(batchEndpoint, config.APIKey, model.ID, config.Language, config.Keywords, registryProvider)
+	case provider.AdapterWhisperServer:
+		adapter = NewWhisperServerAdapter(batchEndpoint, config.Language)
 	case provider.AdapterElevenLabs:
 		adapter = NewElevenLabsAdapter(model.Endpoint, config.APIKey, model.ID, config.Language, config.Keywords)
 	case provider.AdapterDeepgram:


### PR DESCRIPTION
## Summary

- Adds a new `whisper-server` provider that connects to a locally-running [whisper.cpp server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) via its native `/inference` multipart/form-data endpoint
- Adds `base_url` to `ProviderConfig` so users can point at any host/port (e.g. `http://127.0.0.1:8080`)
- Handles both single-object and newline-delimited JSON responses from the server
- Docs updated in `config.md` and `providers.md` with configuration examples and setup notes

## Why

The existing `whisper-cpp` provider shells out to the `whisper-cli` binary. This new provider covers the case where users run whisper.cpp in server mode (or a compatible server like `faster-whisper-server`) and want hyprvoice to hit it over HTTP — useful for shared servers, GPU machines, or setups where the server is already running for other tools.

## Config example

```toml
[providers.whisper-server]
  base_url = "http://127.0.0.1:8080"

[transcription]
  provider = "whisper-server"
  model = "whisper-1"  # ignored by whisper.cpp; model is set at server startup
  language = ""
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `whisper-server` transcription provider that sends audio to a locally-running [whisper.cpp HTTP server](https://github.com/ggml-org/whisper.cpp/tree/master/examples/server) via its native `/inference` multipart/form-data endpoint, covering the case where users run whisper.cpp in server mode (shared GPU machine, LAN server, etc.) rather than shelling out to the `whisper-cli` binary. The implementation follows the existing provider/adapter pattern cleanly, and the config-layer changes (`base_url` in `ProviderConfig`, validation, and conversion) are well-structured.

Key changes:
- **`internal/provider/whisper_server.go`** — new provider with three models (`whisper-1`, `whisper-large-v3`, `whisper-large-v3-turbo`), all routing to `/inference`
- **`internal/transcriber/adapter_whisper_server.go`** — new `BatchAdapter` that POSTs WAV audio as multipart/form-data and decodes single-object or newline-delimited JSON responses
- **`internal/config/types.go` / `convert.go` / `validate.go`** — adds `base_url` to `ProviderConfig` with URL validation and propagation to the transcriber config
- **`internal/transcriber/transcriber.go`** — wires `BaseURL` override into batch endpoint resolution and dispatches to the new adapter
- **Docs** — `config.md` and `providers.md` updated with setup examples

Issues found:
- The `whisper-1` model ID is shared between the `openai` and `whisper-server` providers, causing `FindModelByID("whisper-1")` to silently return OpenAI's cloud model (first-registered wins). This breaks the `model download whisper-1` CLI command for `whisper-server` users.
- URL construction via string concatenation (`BaseURL + Path`) produces a double-slash path (`//inference`) when `base_url` is set with a trailing slash — the validator does not strip it.
- The adapter does not send a `model` form field to the server, but the PR description and docs state that it does. This is inconsistent and may affect `faster-whisper-server` compatibility.

<h3>Confidence Score: 3/5</h3>

- Safe to merge for basic whisper.cpp usage, but has a URL construction bug and a model ID collision that should be addressed before wider adoption.
- The core adapter logic is sound and follows existing patterns. However, two P1 issues lower confidence: the trailing-slash URL bug will silently produce broken requests for users who include a trailing slash in `base_url`, and the `whisper-1` model ID collision with the OpenAI provider causes misleading CLI behaviour. The missing `model` field is a docs/code discrepancy that may also affect `faster-whisper-server` users.
- Pay close attention to `internal/transcriber/adapter_whisper_server.go` (URL construction, missing model field, no HTTP timeout) and `internal/provider/whisper_server.go` (model ID collision with openai provider).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/transcriber/adapter_whisper_server.go | New adapter POSTing multipart/form-data to whisper.cpp's /inference endpoint. Contains a trailing-slash URL bug, a missing `model` field inconsistency with docs, and uses `http.DefaultClient` with no timeout. |
| internal/provider/whisper_server.go | New provider definition exposing three models, all sharing the same default endpoint. The `whisper-1` model ID collides with OpenAI's registered model, causing `FindModelByID` ambiguity. |
| internal/transcriber/transcriber.go | Wires `BaseURL` override into the batch endpoint resolution and adds the `AdapterWhisperServer` case. ElevenLabs/Deepgram adapters intentionally keep `model.Endpoint` — this looks correct. |
| internal/config/validate.go | Adds `base_url` validation using `url.Parse`. Correctly rejects non-http(s) schemes and empty hosts, but doesn't strip trailing slashes, allowing a subtle URL construction bug downstream. |
| internal/provider/provider_test.go | Test updated to use `gpt-4o-transcribe` instead of `whisper-1` for `FindModelByID`, acknowledging the new model ID collision — but no new test coverage for the `whisper-server` provider itself. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User (hotkey)
    participant D as Daemon
    participant T as NewTranscriber
    participant WS as WhisperServerAdapter
    participant S as whisper.cpp HTTP Server

    U->>D: Super+R (toggle)
    D->>D: Record audio frames
    U->>D: Super+R (stop)
    D->>T: NewTranscriber(Config{Provider:"whisper-server", BaseURL:"..."})
    T->>T: Resolve batchEndpoint (BaseURL override)
    T->>WS: NewWhisperServerAdapter(endpoint, language)
    D->>WS: Transcribe(ctx, audioData)
    WS->>WS: convertToWAV(audioData)
    WS->>WS: Build multipart/form-data (file, response_format, temperature, language)
    WS->>S: POST {BaseURL}/inference
    S-->>WS: 200 OK (JSON or NDJSON)
    WS->>WS: Decode JSON stream, join parts
    WS-->>D: transcribed text
    D->>D: Inject text via ydotool/wtype/clipboard
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/transcriber/adapter_whisper_server.go
Line: 67

Comment:
**Trailing slash in BaseURL produces double-slash URL**

String concatenation of `BaseURL + Path` will generate a malformed URL like `http://localhost:8080//inference` if the user sets `base_url = "http://localhost:8080/"` (a trailing slash). The config validator in `validate.go` accepts URLs with trailing slashes since they are valid per `url.Parse`, so this is not caught at startup — it silently produces a broken endpoint. Many HTTP servers (including whisper.cpp) will return 404 or redirect on `//inference`.

```suggestion
	url := strings.TrimRight(a.endpoint.BaseURL, "/") + a.endpoint.Path
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/provider/whisper_server.go
Line: 34

Comment:
**Model ID `whisper-1` collides with OpenAI provider**

`whisper-1` is already registered as a model in the `openai` provider. `FindModelByID` (used in `cmd/hyprvoice/main.go` at lines 418 and 475 for the `model download` command) iterates providers in registration order and returns the first hit. Since OpenAI is registered before `WhisperServerProvider`, `FindModelByID("whisper-1")` always returns OpenAI's cloud model.

This means that if a user running `whisper-server` runs `hyprvoice model download whisper-1`, they will see _"model 'whisper-1' is a cloud model and does not require download"_ — which is confusing and incorrect in their context. The test in `provider_test.go` was already changed from `whisper-1` to `gpt-4o-transcribe` specifically to avoid this ambiguity, implicitly acknowledging the collision.

Consider using a `whisper-server`-namespaced model ID (e.g. `whisper-server-default`, or simply document that model IDs for this provider are purely cosmetic labels that are ignored by the server at runtime).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/transcriber/adapter_whisper_server.go
Line: 57-63

Comment:
**`model` field is not sent, but documentation states it is**

The PR description and `docs/providers.md` both state _"The `model` field in hyprvoice config is sent in the request"_. However, the adapter only writes `response_format`, `temperature`, and (optionally) `language` — it never writes a `model` form field. This discrepancy is harmless for whisper.cpp (which ignores it), but `faster-whisper-server`, listed as a supported backend, may use the `model` field for routing or validation. If support for `faster-whisper-server` is intended, the model field should be written:

```go
_ = w.WriteField("response_format", "json")
_ = w.WriteField("temperature", "0.0")
if a.model != "" {
    _ = w.WriteField("model", a.model)
}
```

(Requires adding a `model string` field to `WhisperServerAdapter` and threading it through `NewWhisperServerAdapter`.)

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/transcriber/adapter_whisper_server.go
Line: 75

Comment:
**No HTTP client timeout**

`http.DefaultClient` has no configured timeout. While the request context (`http.NewRequestWithContext`) does propagate cancellation, if the server is reachable but extremely slow, the call can block for an arbitrarily long time. The ElevenLabs adapter uses `&http.Client{Timeout: 30 * time.Second}` for the same reason. Consider using a dedicated client for consistency:

```go
resp, err := (&http.Client{Timeout: 30 * time.Second}).Do(req)
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: ["feat: add whisper-se..."](https://github.com/leonardotrapani/hyprvoice/commit/1611bad00a427e23cb11f21d611f089fb13a1d2c)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->