### PR TITLE
feat(backend): add dotool backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Press a toggle key, speak, and get instant text input. Built natively for Waylan
 - 26 speech-to-text models across cloud and local providers, including whisper.cpp.
 - Optional LLM post-processing for grammar, punctuation, and more.
 - Toggle workflow with optional status notifications and cancel support.
-- Text injection via ydotool, wtype, and clipboard fallback with clipboard restore.
+- Text injection via ydotool, wtype, dotool, and clipboard fallback with clipboard restore.
 - Guided onboarding and a full configure menu with hot-reload.
 - Personalization through custom prompt and keywords sent both to LLM and to voice model.
 - Whisprflow quality but for linux and open source.

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ flowchart LR
   subgraph Pipeline
     A["Audio Capture"]
     T["Transcribing"]
-    I["Injecting (wtype + clipboard)"]
+    I["Injecting (ydotool + wtype + dotool + clipboard)"]
   end
   N["notify-send/log"]
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -12,7 +12,7 @@ Hyprvoice is split into a thin CLI and a long-lived daemon. The CLI sends single
 - Recording: PipeWire capture (`internal/recording/`).
 - Transcription: batch + streaming adapters (`internal/transcriber/`).
 - LLM post-processing: adapters and prompt builders (`internal/llm/`).
-- Injection: wtype/ydotool/clipboard backends (`internal/injection/`).
+- Injection: wtype/ydotool/dotool/clipboard backends (`internal/injection/`).
 - Provider registry: model metadata and adapter selection (`internal/provider/`).
 - Config manager: load/validate + hot reload (`internal/config/`).
 
@@ -66,8 +66,9 @@ The pipeline invokes LLM processing only if enabled in config.
 `internal/injection/injection.go` defines `Injector` and an ordered list of backends.
 `internal/injection/backend.go` defines the `Backend` interface (`Name/Available/Inject`).
 Backends include:
-- `wtype` (Wayland typing)
 - `ydotool` (uinput typing)
+- `wtype` (Wayland typing)
+- `dotool` (keystroke via dotool)
 - `wl-clipboard` fallback
 
 The injector tries backends in order and falls back to clipboard when typing fails.

--- a/docs/config.md
+++ b/docs/config.md
@@ -455,10 +455,13 @@ Configurable text injection with multiple backends:
 
 ```toml
 [injection]
-backends = ["ydotool", "wtype", "clipboard"]  # Ordered fallback chain
+backends = ["ydotool", "wtype", "clipboard", "dotool"]  # Ordered fallback chain
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
 clipboard_timeout = "3s"
+dotool_timeout = "5s"
+dotool_typedelay = "1ms"
+dotool_typehold = "2ms"
 ```
 
 ### Injection Backends
@@ -466,6 +469,7 @@ clipboard_timeout = "3s"
 - **`ydotool`**: Uses ydotool (requires `ydotoold` daemon for ydotool v1.0.0+). Most compatible with Chromium/Electron apps.
 - **`wtype`**: Uses wtype for Wayland. May have issues with some Chromium-based apps (known upstream bug).
 - **`clipboard`**: Copies text to clipboard only. Most reliable, but requires manual paste.
+- **`dotool`**: Uses dotool (incredibly fast typing simulation using uinput, requires the user to be in the `input` group)
 
 ### Fallback Chain
 
@@ -479,7 +483,7 @@ backends = ["clipboard"]
 backends = ["wtype", "clipboard"]
 
 # Full fallback chain (default) - best compatibility
-backends = ["ydotool", "wtype", "clipboard"]
+backends = ["ydotool", "wtype", "clipboard", "dotool"]
 
 # ydotool only (if you have it set up)
 backends = ["ydotool"]
@@ -502,6 +506,38 @@ sudo usermod -aG input $USER
 #     kb_layout = us
 # }
 ```
+
+### dotool Setup
+
+dotool requires the dotoold daemon running and access to `/dev/uinput`.
+
+```bash
+sudo usermod -aG input $USER
+# Then logout/login
+```
+
+This backend relies on dotoold/dotoolc for minimal latency, so you need to make sure dotoold is running, you can start it manually, or write a small user-level systemd service, like this:
+
+```ini
+[Unit]
+Description=dotool daemon
+Documentation=https://sr.ht/~geb/dotool/
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/dotoold
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=hyprvoice.service
+```
+
+```bash
+systemctl --user enable --now dotoold.service
+```
+
+The default configuration for dotool typing is 1ms between keys and 2ms hold, you can try decreasing them further, but at some point it breaks (the contributor who added this backend uses 0ms and 1ms respectively).
 
 ## Notifications
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -468,7 +468,7 @@ clipboard_timeout = "3s"
 
 - **`ydotool`**: Uses ydotool (requires `ydotoold` daemon for ydotool v1.0.0+). Most compatible with Chromium/Electron apps.
 - **`wtype`**: Uses wtype for Wayland. May have issues with some Chromium-based apps (known upstream bug).
-- **`dotool`**: Uses dotool via dotoold/dotoolc for low-latency keystroke simulation.
+- **`dotool`**: Uses dotoold/dotoolc when the daemon is running, otherwise falls back to direct `dotool`.
 - **`clipboard`**: Copies text to clipboard only. Most reliable, but requires manual paste.
 
 ### Fallback Chain
@@ -509,14 +509,14 @@ sudo usermod -aG input $USER
 
 ### dotool Setup
 
-dotool requires the dotoold daemon running and access to `/dev/uinput`.
+dotool requires access to `/dev/uinput`. It uses dotoold/dotoolc automatically when dotoold is already running, and falls back to direct `dotool` when it is not.
 
 ```bash
 sudo usermod -aG input $USER
 # Then logout/login
 ```
 
-This backend relies on dotoold/dotoolc for minimal latency, so you need to make sure dotoold is running, you can start it manually, or write a small user-level systemd service, like this:
+dotoold is optional but recommended for minimal latency. When dotoold is used, `dotoolc` queues commands and may return before typing has fully finished. You can start dotoold manually, or write a small user-level systemd service, like this:
 
 ```ini
 [Unit]

--- a/docs/config.md
+++ b/docs/config.md
@@ -468,8 +468,8 @@ clipboard_timeout = "3s"
 
 - **`ydotool`**: Uses ydotool (requires `ydotoold` daemon for ydotool v1.0.0+). Most compatible with Chromium/Electron apps.
 - **`wtype`**: Uses wtype for Wayland. May have issues with some Chromium-based apps (known upstream bug).
+- **`dotool`**: Uses dotool via dotoold/dotoolc for low-latency keystroke simulation.
 - **`clipboard`**: Copies text to clipboard only. Most reliable, but requires manual paste.
-- **`dotool`**: Uses dotool (incredibly fast typing simulation using uinput, requires the user to be in the `input` group)
 
 ### Fallback Chain
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -455,13 +455,13 @@ Configurable text injection with multiple backends:
 
 ```toml
 [injection]
-backends = ["ydotool", "wtype", "clipboard", "dotool"]  # Ordered fallback chain
+backends = ["ydotool", "wtype", "dotool", "clipboard"]  # Ordered fallback chain
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
-clipboard_timeout = "3s"
 dotool_timeout = "5s"
 dotool_typedelay = "1ms"
 dotool_typehold = "2ms"
+clipboard_timeout = "3s"
 ```
 
 ### Injection Backends
@@ -483,7 +483,7 @@ backends = ["clipboard"]
 backends = ["wtype", "clipboard"]
 
 # Full fallback chain (default) - best compatibility
-backends = ["ydotool", "wtype", "clipboard", "dotool"]
+backends = ["ydotool", "wtype", "dotool", "clipboard"]
 
 # ydotool only (if you have it set up)
 backends = ["ydotool"]

--- a/docs/structure.md
+++ b/docs/structure.md
@@ -25,7 +25,7 @@ State machine: idle -> recording -> transcribing -> processing -> injecting -> i
 - internal/recording: PipeWire audio capture
 - internal/transcriber: batch and streaming provider adapters
 - internal/llm: post-processing adapters and prompts
-- internal/injection: wtype/ydotool/clipboard injection
+- internal/injection: wtype/ydotool/dotool/clipboard injection
 - internal/notify: desktop notifications
 - internal/provider: provider registry and model metadata
 - internal/models/whisper: local whisper model registry and downloads

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,9 +33,13 @@ func createTestConfig() *Config {
 			"openai": {APIKey: "test-api-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends:         []string{"ydotool", "wtype", "clipboard"},
+			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Enabled: true,
@@ -60,9 +64,13 @@ func createTestConfigWithInvalidValues() *Config {
 			Model:    "", // Invalid
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"invalid"}, YdotoolTimeout: 5 * time.Second, // Invalid
+			Backends:         []string{"invalid"}, // Invalid
+			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     0, // Invalid
 			ClipboardTimeout: 0, // Invalid
+			DotoolTimeout:    0, // Invalid
+			DotoolTypedelay:  0,
+			DotoolTypehold:   0,
 		},
 		Notifications: NotificationsConfig{
 			Type: "invalid", // Invalid
@@ -105,9 +113,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "log",
@@ -134,9 +146,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "log",
@@ -163,9 +179,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"invalid"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"invalid"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "log",
@@ -192,9 +212,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "invalid",
@@ -222,9 +246,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "log",
@@ -252,9 +280,13 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
+					DotoolTimeout:    5 * time.Second,
+					DotoolTypedelay:  1 * time.Millisecond,
+					DotoolTypehold:   2 * time.Millisecond,
 				},
 				Notifications: NotificationsConfig{
 					Type: "log",
@@ -337,6 +369,9 @@ backends = ["ydotool", "wtype", "clipboard"]
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
 clipboard_timeout = "3s"
+dotool_timeout = "5s"
+dotool_typedelay = "1ms"
+dotool_typehold = "2ms"
 
 [notifications]
 enabled = true
@@ -904,6 +939,9 @@ func TestConfig_Validate_OpenAI_WithoutAPIKey(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -943,6 +981,9 @@ func TestConfig_Validate_OpenAI_WithEnvVarAPIKey(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -987,6 +1028,9 @@ func TestConfig_Validate_RecordingTimeout(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1020,6 +1064,9 @@ func TestConfig_Validate_InjectionTimeouts(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     0, // Invalid timeout
 			ClipboardTimeout: 0, // Invalid timeout
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1053,6 +1100,9 @@ func TestConfig_Validate_RecordingBufferSizes(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1087,6 +1137,9 @@ func TestConfig_Validate_GroqTranscription(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1121,6 +1174,9 @@ func TestConfig_Validate_GroqInvalidModel(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1151,6 +1207,9 @@ func TestConfig_Validate_GroqWithoutAPIKey(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1190,6 +1249,9 @@ func TestConfig_Validate_GroqWithEnvVarAPIKey(t *testing.T) {
 			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Type: "log",
@@ -1314,6 +1376,9 @@ func TestConfig_ProvidersMap(t *testing.T) {
 			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{Type: "log"},
 	}
@@ -1368,6 +1433,9 @@ func TestConfig_LLMConfig(t *testing.T) {
 			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{Type: "log"},
 	}
@@ -1430,6 +1498,9 @@ func TestConfig_LLMValidation(t *testing.T) {
 				YdotoolTimeout:   5 * time.Second,
 				WtypeTimeout:     5 * time.Second,
 				ClipboardTimeout: 3 * time.Second,
+				DotoolTimeout:    5 * time.Second,
+				DotoolTypedelay:  1 * time.Millisecond,
+				DotoolTypehold:   2 * time.Millisecond,
 			},
 			Notifications: NotificationsConfig{Type: "log"},
 		}
@@ -1551,6 +1622,9 @@ backends = ["clipboard"]
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
 clipboard_timeout = "3s"
+dotool_timeout = "5s"
+dotool_typedelay = "1ms"
+dotool_typehold = "2ms"
 
 [notifications]
 type = "log"`
@@ -1691,6 +1765,9 @@ func TestConfig_Validate_WhisperCpp(t *testing.T) {
 				YdotoolTimeout:   5 * time.Second,
 				WtypeTimeout:     5 * time.Second,
 				ClipboardTimeout: 3 * time.Second,
+				DotoolTimeout:    5 * time.Second,
+				DotoolTypedelay:  1 * time.Millisecond,
+				DotoolTypehold:   2 * time.Millisecond,
 			},
 			Notifications: NotificationsConfig{Type: "log"},
 		}
@@ -1891,6 +1968,9 @@ func TestConfig_Validate_TranscriptionLanguage(t *testing.T) {
 				YdotoolTimeout:   5 * time.Second,
 				WtypeTimeout:     5 * time.Second,
 				ClipboardTimeout: 3 * time.Second,
+				DotoolTimeout:    5 * time.Second,
+				DotoolTypedelay:  1 * time.Millisecond,
+				DotoolTypehold:   2 * time.Millisecond,
 			},
 			Notifications: NotificationsConfig{Type: "log"},
 		}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -33,7 +33,7 @@ func createTestConfig() *Config {
 			"openai": {APIKey: "test-api-key"},
 		},
 		Injection: InjectionConfig{
-			Backends:         []string{"ydotool", "wtype", "clipboard"},
+			Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,
@@ -113,7 +113,7 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
@@ -146,7 +146,7 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
@@ -212,7 +212,7 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
@@ -246,7 +246,7 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
@@ -280,7 +280,7 @@ func TestConfig_Validate(t *testing.T) {
 					"openai": {APIKey: "test-key"},
 				},
 				Injection: InjectionConfig{
-					Backends:         []string{"ydotool", "wtype", "clipboard"},
+					Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 					YdotoolTimeout:   5 * time.Second,
 					WtypeTimeout:     time.Second,
 					ClipboardTimeout: time.Second,
@@ -365,7 +365,7 @@ provider = "openai"
 model = "whisper-1"
 
 [injection]
-backends = ["ydotool", "wtype", "clipboard"]
+backends = ["ydotool", "wtype", "dotool", "clipboard"]
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
 clipboard_timeout = "3s"
@@ -936,7 +936,7 @@ func TestConfig_Validate_OpenAI_WithoutAPIKey(t *testing.T) {
 			Model:    "whisper-1",
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -978,7 +978,7 @@ func TestConfig_Validate_OpenAI_WithEnvVarAPIKey(t *testing.T) {
 			Model:    "whisper-1",
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1025,7 +1025,7 @@ func TestConfig_Validate_RecordingTimeout(t *testing.T) {
 			"openai": {APIKey: "test-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1061,7 +1061,7 @@ func TestConfig_Validate_InjectionTimeouts(t *testing.T) {
 			"openai": {APIKey: "test-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     0, // Invalid timeout
 			ClipboardTimeout: 0, // Invalid timeout
 			DotoolTimeout:    5 * time.Second,
@@ -1097,7 +1097,7 @@ func TestConfig_Validate_RecordingBufferSizes(t *testing.T) {
 			"openai": {APIKey: "test-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1134,7 +1134,7 @@ func TestConfig_Validate_GroqTranscription(t *testing.T) {
 			"groq": {APIKey: "gsk-test-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1171,7 +1171,7 @@ func TestConfig_Validate_GroqInvalidModel(t *testing.T) {
 			"groq": {APIKey: "gsk-test-key"},
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1204,7 +1204,7 @@ func TestConfig_Validate_GroqWithoutAPIKey(t *testing.T) {
 			Model:    "whisper-large-v3",
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,
@@ -1246,7 +1246,7 @@ func TestConfig_Validate_GroqWithEnvVarAPIKey(t *testing.T) {
 			Model:    "whisper-large-v3",
 		},
 		Injection: InjectionConfig{
-			Backends: []string{"ydotool", "wtype", "clipboard"}, YdotoolTimeout: 5 * time.Second,
+			Backends: []string{"ydotool", "wtype", "dotool", "clipboard"}, YdotoolTimeout: 5 * time.Second,
 			WtypeTimeout:     time.Second,
 			ClipboardTimeout: time.Second,
 			DotoolTimeout:    5 * time.Second,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1749,6 +1749,88 @@ func TestConfig_LLMDefaultsPreserveExplicit(t *testing.T) {
 	}
 }
 
+func TestConfig_Load_DotoolDefaultsForMissingFields(t *testing.T) {
+	config := loadConfigFromString(t, `
+[recording]
+sample_rate = 16000
+channels = 1
+format = "s16"
+buffer_size = 8192
+channel_buffer_size = 30
+timeout = "5m"
+
+[transcription]
+provider = "openai"
+model = "whisper-1"
+
+[providers.openai]
+api_key = "test-key"
+
+[injection]
+backends = ["clipboard"]
+ydotool_timeout = "5s"
+wtype_timeout = "5s"
+clipboard_timeout = "3s"
+
+[notifications]
+type = "log"
+`)
+
+	if config.Injection.DotoolTimeout != 5*time.Second {
+		t.Errorf("DotoolTimeout = %v, want 5s", config.Injection.DotoolTimeout)
+	}
+	if config.Injection.DotoolTypedelay != time.Millisecond {
+		t.Errorf("DotoolTypedelay = %v, want 1ms", config.Injection.DotoolTypedelay)
+	}
+	if config.Injection.DotoolTypehold != 2*time.Millisecond {
+		t.Errorf("DotoolTypehold = %v, want 2ms", config.Injection.DotoolTypehold)
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Validate() error = %v", err)
+	}
+}
+
+func TestConfig_Load_PreservesExplicitDotoolZeroDelays(t *testing.T) {
+	config := loadConfigFromString(t, `
+[recording]
+sample_rate = 16000
+channels = 1
+format = "s16"
+buffer_size = 8192
+channel_buffer_size = 30
+timeout = "5m"
+
+[transcription]
+provider = "openai"
+model = "whisper-1"
+
+[providers.openai]
+api_key = "test-key"
+
+[injection]
+backends = ["dotool", "clipboard"]
+ydotool_timeout = "5s"
+wtype_timeout = "5s"
+clipboard_timeout = "3s"
+dotool_timeout = "5s"
+dotool_typedelay = "0s"
+dotool_typehold = "0s"
+
+[notifications]
+type = "log"
+`)
+
+	if config.Injection.DotoolTypedelay != 0 {
+		t.Errorf("DotoolTypedelay = %v, want explicit 0s", config.Injection.DotoolTypedelay)
+	}
+	if config.Injection.DotoolTypehold != 0 {
+		t.Errorf("DotoolTypehold = %v, want explicit 0s", config.Injection.DotoolTypehold)
+	}
+	if err := config.Validate(); err != nil {
+		t.Errorf("Validate() error = %v", err)
+	}
+}
+
 func TestConfig_Validate_WhisperCpp(t *testing.T) {
 	baseConfig := func() *Config {
 		return &Config{
@@ -2088,4 +2170,25 @@ type = "log"`
 			t.Errorf("Expected effective language 'es', got %q", transcriberConfig.Language)
 		}
 	})
+}
+
+func loadConfigFromString(t *testing.T, content string) *Config {
+	t.Helper()
+
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "hyprvoice", "config.toml")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0755); err != nil {
+		t.Fatalf("Failed to create config directory: %v", err)
+	}
+	if err := os.WriteFile(configPath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create config file: %v", err)
+	}
+
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+
+	config, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	return config
 }

--- a/internal/config/convert.go
+++ b/internal/config/convert.go
@@ -110,5 +110,8 @@ func (c *Config) ToInjectionConfig() injection.Config {
 		YdotoolTimeout:   c.Injection.YdotoolTimeout,
 		WtypeTimeout:     c.Injection.WtypeTimeout,
 		ClipboardTimeout: c.Injection.ClipboardTimeout,
+		DotoolTimeout:    c.Injection.DotoolTimeout,
+		DotoolTypedelay:  c.Injection.DotoolTypedelay,
+		DotoolTypehold:   c.Injection.DotoolTypehold,
 	}
 }

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -20,10 +20,13 @@ func DefaultConfig() *Config {
 			Threads:   0,
 		},
 		Injection: InjectionConfig{
-			Backends:         []string{"ydotool", "wtype", "clipboard"},
+			Backends:         []string{"ydotool", "wtype", "clipboard", "dotool"},
 			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,
+			DotoolTimeout:    5 * time.Second,
+			DotoolTypedelay:  1 * time.Millisecond,
+			DotoolTypehold:   2 * time.Millisecond,
 		},
 		Notifications: NotificationsConfig{
 			Enabled: false,

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -20,7 +20,7 @@ func DefaultConfig() *Config {
 			Threads:   0,
 		},
 		Injection: InjectionConfig{
-			Backends:         []string{"ydotool", "wtype", "clipboard", "dotool"},
+			Backends:         []string{"ydotool", "wtype", "dotool", "clipboard"},
 			YdotoolTimeout:   5 * time.Second,
 			WtypeTimeout:     5 * time.Second,
 			ClipboardTimeout: 3 * time.Second,

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 
 	"github.com/BurntSushi/toml"
 )
@@ -70,6 +71,7 @@ func LoadOrLegacy() (*Config, bool, error) {
 
 	config.applyLLMDefaults()
 	config.applyThreadsDefault()
+	config.applyInjectionDefaults()
 
 	log.Printf("Config: configuration loaded successfully")
 	return &config, false, nil
@@ -110,5 +112,34 @@ func (c *Config) applyLLMDefaults() {
 		pp.AddPunctuation = true
 		pp.FixGrammar = true
 		pp.RemoveFillerWords = true
+	}
+}
+
+// applyInjectionDefaults coerces zero timeout values to defaults
+func (c *Config) applyInjectionDefaults() {
+	const (
+		defaultTimeout = 5000 * time.Millisecond
+		defaultClipboardTimeout = 3000 * time.Millisecond
+		defaultTypedelay = 1 * time.Millisecond
+		defaultTypehold = 2 * time.Millisecond
+	)
+
+	if c.Injection.DotoolTimeout <= 0 {
+		c.Injection.DotoolTimeout = defaultTimeout
+	}
+	if c.Injection.YdotoolTimeout <= 0 {
+		c.Injection.YdotoolTimeout = defaultTimeout
+	}
+	if c.Injection.WtypeTimeout <= 0 {
+		c.Injection.WtypeTimeout = defaultTimeout
+	}
+	if c.Injection.ClipboardTimeout <= 0 {
+		c.Injection.ClipboardTimeout = defaultClipboardTimeout
+	}
+	if c.Injection.DotoolTypedelay < 0 {
+		c.Injection.DotoolTypedelay = defaultTypedelay
+	}
+	if c.Injection.DotoolTypehold < 0 {
+		c.Injection.DotoolTypehold = defaultTypehold
 	}
 }

--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -71,7 +71,7 @@ func LoadOrLegacy() (*Config, bool, error) {
 
 	config.applyLLMDefaults()
 	config.applyThreadsDefault()
-	config.applyInjectionDefaults()
+	config.applyInjectionDefaults(meta)
 
 	log.Printf("Config: configuration loaded successfully")
 	return &config, false, nil
@@ -115,8 +115,8 @@ func (c *Config) applyLLMDefaults() {
 	}
 }
 
-// applyInjectionDefaults coerces zero timeout values to defaults
-func (c *Config) applyInjectionDefaults() {
+// applyInjectionDefaults applies defaults only for missing fields (not explicitly set in TOML)
+func (c *Config) applyInjectionDefaults(meta toml.MetaData) {
 	const (
 		defaultTimeout = 5000 * time.Millisecond
 		defaultClipboardTimeout = 3000 * time.Millisecond
@@ -124,22 +124,23 @@ func (c *Config) applyInjectionDefaults() {
 		defaultTypehold = 2 * time.Millisecond
 	)
 
-	if c.Injection.DotoolTimeout <= 0 {
-		c.Injection.DotoolTimeout = defaultTimeout
-	}
-	if c.Injection.YdotoolTimeout <= 0 {
+	// Only apply defaults if field was not explicitly defined in TOML
+	if !meta.IsDefined("injection", "ydotool_timeout") && c.Injection.YdotoolTimeout == 0 {
 		c.Injection.YdotoolTimeout = defaultTimeout
 	}
-	if c.Injection.WtypeTimeout <= 0 {
+	if !meta.IsDefined("injection", "wtype_timeout") && c.Injection.WtypeTimeout == 0 {
 		c.Injection.WtypeTimeout = defaultTimeout
 	}
-	if c.Injection.ClipboardTimeout <= 0 {
+	if !meta.IsDefined("injection", "clipboard_timeout") && c.Injection.ClipboardTimeout == 0 {
 		c.Injection.ClipboardTimeout = defaultClipboardTimeout
 	}
-	if c.Injection.DotoolTypedelay < 0 {
+	if !meta.IsDefined("injection", "dotool_timeout") && c.Injection.DotoolTimeout == 0 {
+		c.Injection.DotoolTimeout = defaultTimeout
+	}
+	if !meta.IsDefined("injection", "dotool_typedelay") && c.Injection.DotoolTypedelay == 0 {
 		c.Injection.DotoolTypedelay = defaultTypedelay
 	}
-	if c.Injection.DotoolTypehold < 0 {
+	if !meta.IsDefined("injection", "dotool_typehold") && c.Injection.DotoolTypehold == 0 {
 		c.Injection.DotoolTypehold = defaultTypehold
 	}
 }

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -117,6 +117,9 @@ func Save(cfg *Config) error {
 	sb.WriteString(fmt.Sprintf("  ydotool_timeout = %q\n", cfg.Injection.YdotoolTimeout.String()))
 	sb.WriteString(fmt.Sprintf("  wtype_timeout = %q\n", cfg.Injection.WtypeTimeout.String()))
 	sb.WriteString(fmt.Sprintf("  clipboard_timeout = %q\n", cfg.Injection.ClipboardTimeout.String()))
+	sb.WriteString(fmt.Sprintf("  dotool_timeout = %q\n", cfg.Injection.DotoolTimeout.String()))
+	sb.WriteString(fmt.Sprintf("  dotool_typedelay = %q\n", cfg.Injection.DotoolTypedelay.String()))
+	sb.WriteString(fmt.Sprintf("  dotool_typehold = %q\n", cfg.Injection.DotoolTypehold.String()))
 	sb.WriteString("\n")
 
 	// Notifications
@@ -272,10 +275,13 @@ keywords = []
 # ─────────────────────────────────────────────────────────────────────────────
 
 [injection]
-  backends = ["ydotool", "wtype", "clipboard"]  # Ordered fallback chain (tries each until one succeeds)
+  backends = ["ydotool", "wtype", "clipboard", "dotool"]  # Ordered fallback chain (tries each until one succeeds)
   ydotool_timeout = "5s"       # Timeout for ydotool commands
   wtype_timeout = "5s"         # Timeout for wtype commands
   clipboard_timeout = "3s"     # Timeout for clipboard operations
+  dotool_timeout = "5s"        # Timeout for dotool commands
+  dotool_typedelay = "1ms"     # Delay between keystrokes for dotool
+  dotool_typehold = "2ms"      # Key hold duration for dotool
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Desktop Notifications

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -336,7 +336,7 @@ keywords = []
 # Injection backends:
 # - "ydotool": Uses ydotool (requires ydotoold daemon). Best for Chromium/Electron apps.
 # - "wtype": Uses wtype for Wayland. May have issues with some Chromium apps.
-# - "dotool": Uses dotool via dotoold/dotoolc for low-latency keystroke simulation.
+# - "dotool": Uses dotoold/dotoolc when running, otherwise direct dotool. dotoolc may return before typing fully finishes.
 # - "clipboard": Copies to clipboard only (most reliable, requires manual paste).
 #
 # Language codes: "" (auto-detect), "en", "it", "es", "fr", "de", "pt", etc.

--- a/internal/config/save.go
+++ b/internal/config/save.go
@@ -275,7 +275,7 @@ keywords = []
 # ─────────────────────────────────────────────────────────────────────────────
 
 [injection]
-  backends = ["ydotool", "wtype", "clipboard", "dotool"]  # Ordered fallback chain (tries each until one succeeds)
+  backends = ["ydotool", "wtype", "dotool", "clipboard"]  # Ordered fallback chain (tries each until one succeeds)
   ydotool_timeout = "5s"       # Timeout for ydotool commands
   wtype_timeout = "5s"         # Timeout for wtype commands
   clipboard_timeout = "3s"     # Timeout for clipboard operations
@@ -336,6 +336,7 @@ keywords = []
 # Injection backends:
 # - "ydotool": Uses ydotool (requires ydotoold daemon). Best for Chromium/Electron apps.
 # - "wtype": Uses wtype for Wayland. May have issues with some Chromium apps.
+# - "dotool": Uses dotool via dotoold/dotoolc for low-latency keystroke simulation.
 # - "clipboard": Copies to clipboard only (most reliable, requires manual paste).
 #
 # Language codes: "" (auto-detect), "en", "it", "es", "fr", "de", "pt", etc.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -74,6 +74,9 @@ type InjectionConfig struct {
 	YdotoolTimeout   time.Duration `toml:"ydotool_timeout"`
 	WtypeTimeout     time.Duration `toml:"wtype_timeout"`
 	ClipboardTimeout time.Duration `toml:"clipboard_timeout"`
+	DotoolTimeout    time.Duration `toml:"dotool_timeout"`
+	DotoolTypedelay  time.Duration `toml:"dotool_typedelay"`
+	DotoolTypehold   time.Duration `toml:"dotool_typehold"`
 }
 
 type NotificationsConfig struct {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -151,10 +151,10 @@ func (c *Config) Validate() error {
 	if len(c.Injection.Backends) == 0 {
 		return fmt.Errorf("invalid injection.backends: empty (must have at least one backend)")
 	}
-	validBackends := map[string]bool{"ydotool": true, "wtype": true, "clipboard": true}
+	validBackends := map[string]bool{"dotool": true, "ydotool": true, "wtype": true, "clipboard": true}
 	for _, backend := range c.Injection.Backends {
 		if !validBackends[backend] {
-			return fmt.Errorf("invalid injection.backends: unknown backend %q (must be ydotool, wtype, or clipboard)", backend)
+			return fmt.Errorf("invalid injection.backends: unknown backend %q (must be dotool, ydotool, wtype, or clipboard)", backend)
 		}
 	}
 	if c.Injection.YdotoolTimeout <= 0 {
@@ -165,6 +165,15 @@ func (c *Config) Validate() error {
 	}
 	if c.Injection.ClipboardTimeout <= 0 {
 		return fmt.Errorf("invalid injection.clipboard_timeout: %v", c.Injection.ClipboardTimeout)
+	}
+	if c.Injection.DotoolTimeout <= 0 {
+		return fmt.Errorf("invalid injection.dotool_timeout: %v", c.Injection.DotoolTimeout)
+	}
+	if c.Injection.DotoolTypedelay < 0 {
+		return fmt.Errorf("invalid injection.dotool_typedelay: %v (must be >= 0; default: 1ms)", c.Injection.DotoolTypedelay)
+	}
+	if c.Injection.DotoolTypehold < 0 {
+		return fmt.Errorf("invalid injection.dotool_typehold: %v (must be >= 0; default: 2ms)", c.Injection.DotoolTypehold)
 	}
 
 	validTypes := map[string]bool{"desktop": true, "log": true, "none": true}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -29,7 +29,7 @@ provider = "openai"
 model = "whisper-1"
 
 [injection]
-backends = ["ydotool", "wtype", "clipboard"]
+backends = ["ydotool", "wtype", "dotool", "clipboard"]
 ydotool_timeout = "5s"
 wtype_timeout = "5s"
 clipboard_timeout = "3s"

--- a/internal/injection/dotool.go
+++ b/internal/injection/dotool.go
@@ -1,0 +1,73 @@
+package injection
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type DotoolBackend struct {
+	delayMs int64
+	holdMs  int64
+}
+
+func NewDotoolBackend(delayMs int64, holdMs int64) Backend {
+	return &DotoolBackend{delayMs: delayMs, holdMs: holdMs}
+
+}
+
+func (c *DotoolBackend) Name() string {
+	return "dotool"
+}
+
+func (c *DotoolBackend) Available() error {
+	if _, err := exec.LookPath("dotoolc"); err != nil {
+		return fmt.Errorf("dotoolc not found: %w (install dotool)", err)
+	}
+
+	return nil
+}
+
+func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Duration) error {
+	if err := c.Available(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "dotoolc")
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		return fmt.Errorf("dotoolc failed: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("dotoolc failed: %w", err)
+	}
+
+	var typeCommands strings.Builder
+	for line := range strings.SplitSeq(text, "\n") {
+		fmt.Fprintf(&typeCommands, "type %s\n", line)
+	}
+
+	if _, err := fmt.Fprintf(input, "typedelay %v\ntypehold %v\n%s", c.delayMs, c.holdMs, typeCommands.String()); err != nil {
+		input.Close()
+		return fmt.Errorf("writing to dotoolc stdin failed: %w", err)
+	}
+
+	input.Close()
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("dotoolc failed: %w\n%s", err, stderr.String())
+	}
+
+	return nil
+}

--- a/internal/injection/dotool.go
+++ b/internal/injection/dotool.go
@@ -16,7 +16,6 @@ type DotoolBackend struct {
 
 func NewDotoolBackend(delayMs int64, holdMs int64) Backend {
 	return &DotoolBackend{delayMs: delayMs, holdMs: holdMs}
-
 }
 
 func (c *DotoolBackend) Name() string {
@@ -53,17 +52,7 @@ func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Du
 		return fmt.Errorf("dotoolc failed: %w", err)
 	}
 
-	var typeCommands strings.Builder
-	lines := strings.Split(text, "\n")
-	for i, line := range lines {
-		fmt.Fprintf(&typeCommands, "type %s\n", line)
-		if i < len(lines)-1 {
-			fmt.Fprintf(&typeCommands, "key Return\n")
-			fmt.Fprintf(&typeCommands, "key enter\n")
-		}
-	}
-
-	if _, err := fmt.Fprintf(input, "typedelay %v\ntypehold %v\n%s", c.delayMs, c.holdMs, typeCommands.String()); err != nil {
+	if _, err := fmt.Fprint(input, c.commandStream(text)); err != nil {
 		input.Close()
 		return fmt.Errorf("writing to dotoolc stdin failed: %w", err)
 	}
@@ -75,4 +64,24 @@ func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Du
 	}
 
 	return nil
+}
+
+func (c *DotoolBackend) commandStream(text string) string {
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	text = strings.ReplaceAll(text, "\r", "\n")
+
+	var stream strings.Builder
+	fmt.Fprintf(&stream, "typedelay %v\ntypehold %v\n", c.delayMs, c.holdMs)
+
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
+		if line != "" {
+			fmt.Fprintf(&stream, "type %s\n", line)
+		}
+		if i < len(lines)-1 {
+			fmt.Fprint(&stream, "key enter\n")
+		}
+	}
+
+	return stream.String()
 }

--- a/internal/injection/dotool.go
+++ b/internal/injection/dotool.go
@@ -54,8 +54,12 @@ func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Du
 	}
 
 	var typeCommands strings.Builder
-	for line := range strings.SplitSeq(text, "\n") {
+	lines := strings.Split(text, "\n")
+	for i, line := range lines {
 		fmt.Fprintf(&typeCommands, "type %s\n", line)
+		if i < len(lines)-1 {
+			fmt.Fprintf(&typeCommands, "key Return\n")
+		}
 	}
 
 	if _, err := fmt.Fprintf(input, "typedelay %v\ntypehold %v\n%s", c.delayMs, c.holdMs, typeCommands.String()); err != nil {

--- a/internal/injection/dotool.go
+++ b/internal/injection/dotool.go
@@ -59,6 +59,7 @@ func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Du
 		fmt.Fprintf(&typeCommands, "type %s\n", line)
 		if i < len(lines)-1 {
 			fmt.Fprintf(&typeCommands, "key Return\n")
+			fmt.Fprintf(&typeCommands, "key enter\n")
 		}
 	}
 

--- a/internal/injection/dotool.go
+++ b/internal/injection/dotool.go
@@ -3,9 +3,12 @@ package injection
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -23,44 +26,124 @@ func (c *DotoolBackend) Name() string {
 }
 
 func (c *DotoolBackend) Available() error {
-	if _, err := exec.LookPath("dotoolc"); err != nil {
-		return fmt.Errorf("dotoolc not found: %w (install dotool)", err)
-	}
-
-	return nil
+	_, err := c.command()
+	return err
 }
 
 func (c *DotoolBackend) Inject(ctx context.Context, text string, timeout time.Duration) error {
-	if err := c.Available(); err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "dotoolc")
+	command, err := c.command()
+	if err != nil {
+		return err
+	}
+
+	cmd := exec.CommandContext(ctx, command)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 
 	input, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("dotoolc failed: %w", err)
+		return fmt.Errorf("%s failed: %w", command, err)
 	}
 
 	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("dotoolc failed: %w", err)
+		return fmt.Errorf("%s failed: %w", command, err)
 	}
 
 	if _, err := fmt.Fprint(input, c.commandStream(text)); err != nil {
 		input.Close()
-		return fmt.Errorf("writing to dotoolc stdin failed: %w", err)
+		return fmt.Errorf("writing to %s stdin failed: %w", command, err)
 	}
 
 	input.Close()
 
 	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("dotoolc failed: %w\n%s", err, stderr.String())
+		return fmt.Errorf("%s failed: %w\n%s", command, err, stderr.String())
+	}
+	if command == "dotool" && stderr.Len() > 0 {
+		return fmt.Errorf("%s completed with warnings:\n%s", command, stderr.String())
+	}
+
+	return nil
+}
+
+func (c *DotoolBackend) command() (string, error) {
+	var daemonErr error
+	if _, err := exec.LookPath("dotoolc"); err == nil {
+		daemonErr = c.dotooldActive()
+		if daemonErr == nil {
+			return "dotoolc", nil
+		}
+	}
+
+	if _, err := exec.LookPath("dotool"); err == nil {
+		return "dotool", nil
+	}
+
+	if daemonErr != nil {
+		return "", fmt.Errorf("dotoold unavailable (%v) and dotool not found (install dotool)", daemonErr)
+	}
+	return "", fmt.Errorf("dotool not found (install dotool)")
+}
+
+func (c *DotoolBackend) dotooldActive() error {
+	pipe := os.Getenv("DOTOOL_PIPE")
+	if pipe == "" {
+		pipe = "/tmp/dotool-pipe"
+	}
+
+	info, err := os.Lstat(pipe)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("dotoold pipe not found at %s", pipe)
+		}
+		return fmt.Errorf("dotoold pipe stat failed at %s: %w", pipe, err)
+	}
+	if err := validateDotoolPipe(pipe, info); err != nil {
+		return err
+	}
+
+	f, err := os.OpenFile(pipe, os.O_WRONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		if errors.Is(err, syscall.ENXIO) {
+			return fmt.Errorf("dotoold not reading pipe at %s", pipe)
+		}
+		return fmt.Errorf("dotoold pipe open failed at %s: %w", pipe, err)
+	}
+	if info, err := f.Stat(); err != nil {
+		f.Close()
+		return fmt.Errorf("dotoold pipe stat failed after open at %s: %w", pipe, err)
+	} else if err := validateDotoolPipe(pipe, info); err != nil {
+		f.Close()
+		return err
+	}
+	f.Close()
+
+	return nil
+}
+
+func validateDotoolPipe(pipe string, info os.FileInfo) error {
+	if info.Mode()&os.ModeNamedPipe == 0 {
+		return fmt.Errorf("dotoold pipe path is not a FIFO: %s", pipe)
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return fmt.Errorf("dotoold pipe stat type unsupported at %s", pipe)
+	}
+	if int(stat.Uid) != os.Getuid() {
+		return fmt.Errorf("dotoold pipe owner mismatch at %s: uid %d", pipe, stat.Uid)
+	}
+
+	perm := info.Mode().Perm()
+	if perm&0200 == 0 {
+		return fmt.Errorf("dotoold pipe is not writable by owner at %s: mode %04o", pipe, perm)
+	}
+	if perm&0017 != 0 {
+		return fmt.Errorf("dotoold pipe has unsafe permissions at %s: mode %04o", pipe, perm)
 	}
 
 	return nil

--- a/internal/injection/dotool_test.go
+++ b/internal/injection/dotool_test.go
@@ -1,0 +1,163 @@
+package injection
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDotoolMultilineHandling(t *testing.T) {
+	tmpDir := t.TempDir()
+	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
+
+	script := `#!/bin/sh
+cat > "$1"
+`
+	if err := os.WriteFile(fakeDotoolc, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to create fake dotoolc: %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		text     string
+		delay    int64
+		hold     int64
+		wantCmds string
+	}{
+		{
+			name:  "single line",
+			text:  "hello",
+			delay: 1,
+			hold:  2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\n",
+		},
+		{
+			name:  "multiline preserves newlines",
+			text:  "hello\nworld",
+			delay: 1,
+			hold:  2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype world\n",
+		},
+		{
+			name:  "three lines",
+			text:  "a\nb\nc",
+			delay: 5,
+			hold:  10,
+			wantCmds: "typedelay 5\ntypehold 10\ntype a\nkey Return\ntype b\nkey Return\ntype c\n",
+		},
+		{
+			name:  "trailing newline",
+			text:  "hello\n",
+			delay: 1,
+			hold:  2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype \n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			backend := NewDotoolBackend(tt.delay, tt.hold)
+			db := backend.(*DotoolBackend)
+
+			var input strings.Builder
+			lines := strings.Split(tt.text, "\n")
+			for i, line := range lines {
+				fmt.Fprintf(&input, "type %s\n", line)
+				if i < len(lines)-1 {
+					fmt.Fprintf(&input, "key Return\n")
+				}
+			}
+
+			got := fmt.Sprintf("typedelay %v\ntypehold %v\n%s", db.delayMs, db.holdMs, input.String())
+			if got != tt.wantCmds {
+				t.Errorf("command stream mismatch\nwant:\n%s\ngot:\n%s", tt.wantCmds, got)
+			}
+		})
+	}
+}
+
+func TestDotoolConfigurableDelays(t *testing.T) {
+	tests := []struct {
+		delay int64
+		hold  int64
+	}{
+		{1, 2},
+		{5, 10},
+		{0, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("delay=%d_hold=%d", tt.delay, tt.hold), func(t *testing.T) {
+			backend := NewDotoolBackend(tt.delay, tt.hold)
+			db := backend.(*DotoolBackend)
+
+			if db.delayMs != tt.delay {
+				t.Errorf("delayMs mismatch: want %d, got %d", tt.delay, db.delayMs)
+			}
+			if db.holdMs != tt.hold {
+				t.Errorf("holdMs mismatch: want %d, got %d", tt.hold, db.holdMs)
+			}
+		})
+	}
+}
+
+func TestDotoolName(t *testing.T) {
+	backend := NewDotoolBackend(1, 2)
+	if name := backend.Name(); name != "dotool" {
+		t.Errorf("Name() = %q, want %q", name, "dotool")
+	}
+}
+
+func TestDotoolAvailableCheck(t *testing.T) {
+	backend := NewDotoolBackend(1, 2)
+
+	err := backend.Available()
+	if err == nil {
+		t.Skip("dotoolc is installed, skipping availability check")
+	}
+	if !strings.Contains(err.Error(), "dotoolc") {
+		t.Errorf("Expected error mentioning dotoolc, got: %v", err)
+	}
+}
+
+func TestDotoolInjectWithFakeCommand(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdinFile := filepath.Join(tmpDir, "stdin.txt")
+
+	fakeScript := fmt.Sprintf(`#!/bin/sh
+cat > "%s"
+exit 0
+`, stdinFile)
+
+	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
+	if err := os.WriteFile(fakeDotoolc, []byte(fakeScript), 0755); err != nil {
+		t.Fatalf("failed to create fake dotoolc: %v", err)
+	}
+
+	oldPath := os.Getenv("PATH")
+	os.Setenv("PATH", tmpDir+":"+oldPath)
+	defer os.Setenv("PATH", oldPath)
+
+	backend := NewDotoolBackend(1, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := backend.Inject(ctx, "hello\nworld", 5*time.Second)
+	if err != nil {
+		t.Fatalf("Inject failed: %v", err)
+	}
+
+	got, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("failed to read captured stdin: %v", err)
+	}
+
+	want := "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype world\n"
+	if string(got) != want {
+		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, string(got))
+	}
+}

--- a/internal/injection/dotool_test.go
+++ b/internal/injection/dotool_test.go
@@ -40,21 +40,21 @@ cat > "$1"
 			text:  "hello\nworld",
 			delay: 1,
 			hold:  2,
-			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype world\n",
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n",
 		},
 		{
 			name:  "three lines",
 			text:  "a\nb\nc",
 			delay: 5,
 			hold:  10,
-			wantCmds: "typedelay 5\ntypehold 10\ntype a\nkey Return\ntype b\nkey Return\ntype c\n",
+			wantCmds: "typedelay 5\ntypehold 10\ntype a\nkey enter\ntype b\nkey enter\ntype c\n",
 		},
 		{
 			name:  "trailing newline",
 			text:  "hello\n",
 			delay: 1,
 			hold:  2,
-			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype \n",
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\n",
 		},
 	}
 
@@ -68,7 +68,7 @@ cat > "$1"
 			for i, line := range lines {
 				fmt.Fprintf(&input, "type %s\n", line)
 				if i < len(lines)-1 {
-					fmt.Fprintf(&input, "key Return\n")
+					fmt.Fprintf(&input, "key enter\n")
 				}
 			}
 
@@ -156,7 +156,7 @@ exit 0
 		t.Fatalf("failed to read captured stdin: %v", err)
 	}
 
-	want := "typedelay 1\ntypehold 2\ntype hello\nkey Return\ntype world\n"
+	want := "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n"
 	if string(got) != want {
 		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, string(got))
 	}

--- a/internal/injection/dotool_test.go
+++ b/internal/injection/dotool_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -117,10 +118,10 @@ func TestDotoolAvailableCheck(t *testing.T) {
 
 	err := backend.Available()
 	if err == nil {
-		t.Skip("dotoolc is installed, skipping availability check")
+		t.Skip("dotool is installed, skipping availability check")
 	}
-	if !strings.Contains(err.Error(), "dotoolc") {
-		t.Errorf("Expected error mentioning dotoolc, got: %v", err)
+	if !strings.Contains(err.Error(), "dotool") {
+		t.Errorf("Expected error mentioning dotool, got: %v", err)
 	}
 }
 
@@ -134,22 +135,185 @@ func TestDotoolInjectWithFakeCommand(t *testing.T) {
 	}
 }
 
+func TestDotoolUsesClientWhenDaemonPipeIsActive(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdinFile := filepath.Join(tmpDir, "stdin.txt")
+	pipe := filepath.Join(tmpDir, "dotool-pipe")
+	if err := syscall.Mkfifo(pipe, 0600); err != nil {
+		t.Fatalf("failed to create fifo: %v", err)
+	}
+
+	reader, err := os.OpenFile(pipe, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+	if err != nil {
+		t.Fatalf("failed to hold fifo reader open: %v", err)
+	}
+	defer reader.Close()
+
+	writeScript(t, filepath.Join(tmpDir, "dotoolc"), fmt.Sprintf(`#!/bin/sh
+/bin/cat > "%s"
+exit 0
+`, stdinFile))
+	writeScript(t, filepath.Join(tmpDir, "dotool"), `#!/bin/sh
+echo wrong-backend >&2
+exit 42
+`)
+
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("DOTOOL_PIPE", pipe)
+
+	backend := NewDotoolBackend(1, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := backend.Inject(ctx, "daemon path", 5*time.Second); err != nil {
+		t.Fatalf("Inject failed: %v", err)
+	}
+
+	gotBytes, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("failed to read captured stdin: %v", err)
+	}
+	want := "typedelay 1\ntypehold 2\ntype daemon path\n"
+	if got := string(gotBytes); got != want {
+		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestDotoolFallsBackToDirectCommandWithoutDaemon(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdinFile := filepath.Join(tmpDir, "stdin.txt")
+
+	writeScript(t, filepath.Join(tmpDir, "dotoolc"), `#!/bin/sh
+echo dotoolc should not run >&2
+exit 42
+`)
+	writeScript(t, filepath.Join(tmpDir, "dotool"), fmt.Sprintf(`#!/bin/sh
+/bin/cat > "%s"
+exit 0
+`, stdinFile))
+
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("DOTOOL_PIPE", filepath.Join(tmpDir, "missing-pipe"))
+
+	backend := NewDotoolBackend(1, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := backend.Inject(ctx, "direct path", 5*time.Second); err != nil {
+		t.Fatalf("Inject failed: %v", err)
+	}
+
+	gotBytes, err := os.ReadFile(stdinFile)
+	if err != nil {
+		t.Fatalf("failed to read captured stdin: %v", err)
+	}
+	want := "typedelay 1\ntypehold 2\ntype direct path\n"
+	if got := string(gotBytes); got != want {
+		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func TestDotoolDirectCommandWarningsFailForFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	stdinFile := filepath.Join(tmpDir, "stdin.txt")
+
+	writeScript(t, filepath.Join(tmpDir, "dotool"), fmt.Sprintf(`#!/bin/sh
+/bin/cat > "%s"
+echo "impossible character for layout: U+1F41F" >&2
+exit 0
+`, stdinFile))
+
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("DOTOOL_PIPE", filepath.Join(tmpDir, "missing-pipe"))
+
+	backend := NewDotoolBackend(1, 2)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := backend.Inject(ctx, "bad char", 5*time.Second)
+	if err == nil {
+		t.Fatal("Inject() nil error, want warning error")
+	}
+	if !strings.Contains(err.Error(), "completed with warnings") {
+		t.Fatalf("Inject() error = %v, want warning error", err)
+	}
+}
+
+func TestDotooldActiveDetection(t *testing.T) {
+	backend := NewDotoolBackend(1, 2).(*DotoolBackend)
+	tmpDir := t.TempDir()
+
+	t.Run("missing pipe", func(t *testing.T) {
+		t.Setenv("DOTOOL_PIPE", filepath.Join(tmpDir, "missing"))
+		if err := backend.dotooldActive(); err == nil {
+			t.Fatal("dotooldActive() nil error, want missing pipe error")
+		}
+	})
+
+	t.Run("fifo without reader", func(t *testing.T) {
+		pipe := filepath.Join(t.TempDir(), "fifo")
+		if err := syscall.Mkfifo(pipe, 0600); err != nil {
+			t.Fatalf("failed to create fifo: %v", err)
+		}
+		t.Setenv("DOTOOL_PIPE", pipe)
+		if err := backend.dotooldActive(); err == nil {
+			t.Fatal("dotooldActive() nil error, want no reader error")
+		}
+	})
+
+	t.Run("fifo with unsafe permissions", func(t *testing.T) {
+		pipe := filepath.Join(t.TempDir(), "fifo")
+		if err := syscall.Mkfifo(pipe, 0600); err != nil {
+			t.Fatalf("failed to create fifo: %v", err)
+		}
+		if err := os.Chmod(pipe, 0666); err != nil {
+			t.Fatalf("failed to chmod fifo: %v", err)
+		}
+		t.Setenv("DOTOOL_PIPE", pipe)
+		err := backend.dotooldActive()
+		if err == nil {
+			t.Fatal("dotooldActive() nil error, want unsafe permissions error")
+		}
+		if !strings.Contains(err.Error(), "unsafe permissions") {
+			t.Fatalf("dotooldActive() error = %v, want unsafe permissions error", err)
+		}
+	})
+
+	t.Run("fifo with reader", func(t *testing.T) {
+		pipe := filepath.Join(t.TempDir(), "fifo")
+		if err := syscall.Mkfifo(pipe, 0600); err != nil {
+			t.Fatalf("failed to create fifo: %v", err)
+		}
+		reader, err := os.OpenFile(pipe, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			t.Fatalf("failed to hold fifo reader open: %v", err)
+		}
+		defer reader.Close()
+
+		t.Setenv("DOTOOL_PIPE", pipe)
+		if err := backend.dotooldActive(); err != nil {
+			t.Fatalf("dotooldActive() error = %v, want nil", err)
+		}
+	})
+}
+
 func captureDotoolStdin(t *testing.T, backend Backend, text string) string {
 	t.Helper()
 
 	tmpDir := t.TempDir()
 	stdinFile := filepath.Join(tmpDir, "stdin.txt")
 	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
+	fakeDotool := filepath.Join(tmpDir, "dotool")
 
 	fakeScript := fmt.Sprintf(`#!/bin/sh
-cat > "%s"
+/bin/cat > "%s"
 exit 0
 `, stdinFile)
-	if err := os.WriteFile(fakeDotoolc, []byte(fakeScript), 0755); err != nil {
-		t.Fatalf("failed to create fake dotoolc: %v", err)
-	}
+	writeScript(t, fakeDotoolc, fakeScript)
+	writeScript(t, fakeDotool, fakeScript)
 
-	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("DOTOOL_PIPE", filepath.Join(tmpDir, "missing-pipe"))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -164,4 +328,11 @@ exit 0
 	}
 
 	return string(got)
+}
+
+func writeScript(t *testing.T, path, script string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("failed to create %s: %v", path, err)
+	}
 }

--- a/internal/injection/dotool_test.go
+++ b/internal/injection/dotool_test.go
@@ -11,16 +11,6 @@ import (
 )
 
 func TestDotoolMultilineHandling(t *testing.T) {
-	tmpDir := t.TempDir()
-	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
-
-	script := `#!/bin/sh
-cat > "$1"
-`
-	if err := os.WriteFile(fakeDotoolc, []byte(script), 0755); err != nil {
-		t.Fatalf("failed to create fake dotoolc: %v", err)
-	}
-
 	tests := []struct {
 		name     string
 		text     string
@@ -29,50 +19,60 @@ cat > "$1"
 		wantCmds string
 	}{
 		{
-			name:  "single line",
-			text:  "hello",
-			delay: 1,
-			hold:  2,
+			name:     "single line",
+			text:     "hello",
+			delay:    1,
+			hold:     2,
 			wantCmds: "typedelay 1\ntypehold 2\ntype hello\n",
 		},
 		{
-			name:  "multiline preserves newlines",
-			text:  "hello\nworld",
-			delay: 1,
-			hold:  2,
+			name:     "multiline preserves newline with enter",
+			text:     "hello\nworld",
+			delay:    1,
+			hold:     2,
 			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n",
 		},
 		{
-			name:  "three lines",
-			text:  "a\nb\nc",
-			delay: 5,
-			hold:  10,
+			name:     "three lines",
+			text:     "a\nb\nc",
+			delay:    5,
+			hold:     10,
 			wantCmds: "typedelay 5\ntypehold 10\ntype a\nkey enter\ntype b\nkey enter\ntype c\n",
 		},
 		{
-			name:  "trailing newline",
-			text:  "hello\n",
-			delay: 1,
-			hold:  2,
-			wantCmds: "typedelay 1\ntypehold 2\ntype hello\n",
+			name:     "blank line",
+			text:     "a\n\nb",
+			delay:    1,
+			hold:     2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype a\nkey enter\nkey enter\ntype b\n",
+		},
+		{
+			name:     "trailing newline",
+			text:     "hello\n",
+			delay:    1,
+			hold:     2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey enter\n",
+		},
+		{
+			name:     "crlf newline",
+			text:     "hello\r\nworld",
+			delay:    1,
+			hold:     2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n",
+		},
+		{
+			name:     "newline does not inject dotool command",
+			text:     "hello\nkey super",
+			delay:    1,
+			hold:     2,
+			wantCmds: "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype key super\n",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			backend := NewDotoolBackend(tt.delay, tt.hold)
-			db := backend.(*DotoolBackend)
-
-			var input strings.Builder
-			lines := strings.Split(tt.text, "\n")
-			for i, line := range lines {
-				fmt.Fprintf(&input, "type %s\n", line)
-				if i < len(lines)-1 {
-					fmt.Fprintf(&input, "key enter\n")
-				}
-			}
-
-			got := fmt.Sprintf("typedelay %v\ntypehold %v\n%s", db.delayMs, db.holdMs, input.String())
+			got := captureDotoolStdin(t, backend, tt.text)
 			if got != tt.wantCmds {
 				t.Errorf("command stream mismatch\nwant:\n%s\ngot:\n%s", tt.wantCmds, got)
 			}
@@ -125,29 +125,36 @@ func TestDotoolAvailableCheck(t *testing.T) {
 }
 
 func TestDotoolInjectWithFakeCommand(t *testing.T) {
+	backend := NewDotoolBackend(1, 2)
+	got := captureDotoolStdin(t, backend, "hello\nworld")
+
+	want := "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n"
+	if got != want {
+		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, got)
+	}
+}
+
+func captureDotoolStdin(t *testing.T, backend Backend, text string) string {
+	t.Helper()
+
 	tmpDir := t.TempDir()
 	stdinFile := filepath.Join(tmpDir, "stdin.txt")
+	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
 
 	fakeScript := fmt.Sprintf(`#!/bin/sh
 cat > "%s"
 exit 0
 `, stdinFile)
-
-	fakeDotoolc := filepath.Join(tmpDir, "dotoolc")
 	if err := os.WriteFile(fakeDotoolc, []byte(fakeScript), 0755); err != nil {
 		t.Fatalf("failed to create fake dotoolc: %v", err)
 	}
 
-	oldPath := os.Getenv("PATH")
-	os.Setenv("PATH", tmpDir+":"+oldPath)
-	defer os.Setenv("PATH", oldPath)
+	t.Setenv("PATH", tmpDir+":"+os.Getenv("PATH"))
 
-	backend := NewDotoolBackend(1, 2)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	err := backend.Inject(ctx, "hello\nworld", 5*time.Second)
-	if err != nil {
+	if err := backend.Inject(ctx, text, 5*time.Second); err != nil {
 		t.Fatalf("Inject failed: %v", err)
 	}
 
@@ -156,8 +163,5 @@ exit 0
 		t.Fatalf("failed to read captured stdin: %v", err)
 	}
 
-	want := "typedelay 1\ntypehold 2\ntype hello\nkey enter\ntype world\n"
-	if string(got) != want {
-		t.Errorf("captured stdin mismatch\nwant:\n%s\ngot:\n%s", want, string(got))
-	}
+	return string(got)
 }

--- a/internal/injection/injection.go
+++ b/internal/injection/injection.go
@@ -16,6 +16,9 @@ type Config struct {
 	YdotoolTimeout   time.Duration // Timeout for ydotool commands
 	WtypeTimeout     time.Duration // Timeout for wtype commands
 	ClipboardTimeout time.Duration // Timeout for clipboard operations
+	DotoolTimeout    time.Duration // Timeout for dotoolc commands
+	DotoolTypedelay  time.Duration // Set the delay between each key
+	DotoolTypehold   time.Duration // Set the hold time for each key
 }
 
 type injector struct {
@@ -34,6 +37,11 @@ func NewInjector(config Config) Injector {
 			backends = append(backends, NewWtypeBackend())
 		case "clipboard":
 			backends = append(backends, NewClipboardBackend())
+		case "dotool":
+			backends = append(backends, NewDotoolBackend(
+				config.DotoolTypedelay.Milliseconds(),
+				config.DotoolTypehold.Milliseconds(),
+			))
 		default:
 			log.Printf("Injection: unknown backend %q, skipping", name)
 		}
@@ -80,6 +88,8 @@ func (i *injector) getTimeout(backendName string) time.Duration {
 		return i.config.WtypeTimeout
 	case "clipboard":
 		return i.config.ClipboardTimeout
+	case "dotool":
+		return i.config.DotoolTimeout
 	default:
 		return 5 * time.Second
 	}

--- a/internal/injection/injection.go
+++ b/internal/injection/injection.go
@@ -16,7 +16,7 @@ type Config struct {
 	YdotoolTimeout   time.Duration // Timeout for ydotool commands
 	WtypeTimeout     time.Duration // Timeout for wtype commands
 	ClipboardTimeout time.Duration // Timeout for clipboard operations
-	DotoolTimeout    time.Duration // Timeout for dotoolc commands
+	DotoolTimeout    time.Duration // Timeout for dotool commands
 	DotoolTypedelay  time.Duration // Set the delay between each key
 	DotoolTypehold   time.Duration // Set the hold time for each key
 }

--- a/internal/injection/injection.go
+++ b/internal/injection/injection.go
@@ -12,7 +12,7 @@ type Injector interface {
 }
 
 type Config struct {
-	Backends         []string      // Ordered list: "ydotool", "wtype", "clipboard"
+	Backends         []string      // Ordered list: "ydotool", "wtype", "dotool", "clipboard"
 	YdotoolTimeout   time.Duration // Timeout for ydotool commands
 	WtypeTimeout     time.Duration // Timeout for wtype commands
 	ClipboardTimeout time.Duration // Timeout for clipboard operations

--- a/internal/tui/flows.go
+++ b/internal/tui/flows.go
@@ -721,7 +721,7 @@ func newAdvancedMenuScreen(state *wizardState, onBack func() screen, onboarding 
 	if !onboarding {
 		items = append(items, optionItem{title: formatInjectionLabel(state.cfg), desc: "Backends for typing and clipboard fallback.", value: "injection"})
 	}
-	items = append(items, optionItem{title: formatAdvancedInjectionTimeoutLabel(state.cfg), desc: "Timeouts for ydotool, wtype, clipboard.", value: "timeouts"})
+	items = append(items, optionItem{title: formatAdvancedInjectionTimeoutLabel(state.cfg), desc: "Timeouts for ydotool, wtype, dotool, and clipboard.", value: "timeouts"})
 	if onboarding {
 		items = append(items, optionItem{title: "Next", desc: "Continue without changing advanced settings.", value: "next"})
 	}

--- a/internal/tui/flows.go
+++ b/internal/tui/flows.go
@@ -554,20 +554,39 @@ func newKeywordsScreen(state *wizardState, onBack func() screen) screen {
 
 func newInjectionScreen(state *wizardState, onBack func() screen) screen {
 	selected := state.cfg.Injection.Backends
+	defaultOrder := []string{"ydotool", "wtype", "dotool", "clipboard"}
 	if len(selected) == 0 {
-		selected = []string{"ydotool", "wtype", "dotool", "clipboard"}
+		selected = defaultOrder
 	}
 	selectedSet := make(map[string]bool, len(selected))
 	for _, b := range selected {
 		selectedSet[b] = true
 	}
 
-	items := []toggleItem{
-		{title: "ydotool", desc: "Best for Chromium/Electron. Requires ydotoold.", value: "ydotool", selected: selectedSet["ydotool"]},
-		{title: "wtype", desc: "Native Wayland typing.", value: "wtype", selected: selectedSet["wtype"]},
-		{title: "dotool", desc: "Send keystrokes via dotool. Requires dotoolc.", value: "dotool", selected: selectedSet["dotool"]},
-		{title: "clipboard", desc: "Copy to clipboard only.", value: "clipboard", selected: selectedSet["clipboard"]},
+	backendItems := map[string]toggleItem{
+		"ydotool":   {title: "ydotool", desc: "Best for Chromium/Electron. Requires ydotoold.", value: "ydotool"},
+		"wtype":     {title: "wtype", desc: "Native Wayland typing.", value: "wtype"},
+		"dotool":    {title: "dotool", desc: "Send keystrokes via dotool. Uses dotoold when running.", value: "dotool"},
+		"clipboard": {title: "clipboard", desc: "Copy to clipboard only.", value: "clipboard"},
 	}
+	items := make([]toggleItem, 0, len(defaultOrder))
+	added := make(map[string]bool, len(defaultOrder))
+	addBackend := func(name string) {
+		item, ok := backendItems[name]
+		if !ok || added[name] {
+			return
+		}
+		item.selected = selectedSet[name]
+		items = append(items, item)
+		added[name] = true
+	}
+	for _, name := range selected {
+		addBackend(name)
+	}
+	for _, name := range defaultOrder {
+		addBackend(name)
+	}
+
 	desc := []string{"Backends are tried in order until one succeeds.", "Tip: press / to filter."}
 	screen := newMultiSelectScreen(state, "Text Injection Backends", desc, items, true, func(items []toggleItem) screen {
 		var backends []string

--- a/internal/tui/flows.go
+++ b/internal/tui/flows.go
@@ -565,6 +565,7 @@ func newInjectionScreen(state *wizardState, onBack func() screen) screen {
 	items := []toggleItem{
 		{title: "ydotool", desc: "Best for Chromium/Electron. Requires ydotoold.", value: "ydotool", selected: selectedSet["ydotool"]},
 		{title: "wtype", desc: "Native Wayland typing.", value: "wtype", selected: selectedSet["wtype"]},
+		{title: "dotool", desc: "Send keystrokes via dotool. Requires dotoolc.", value: "dotool", selected: selectedSet["dotool"]},
 		{title: "clipboard", desc: "Copy to clipboard only.", value: "clipboard", selected: selectedSet["clipboard"]},
 	}
 	desc := []string{"Backends are tried in order until one succeeds.", "Tip: press / to filter."}
@@ -820,6 +821,24 @@ func newInjectionTimeoutsScreen(state *wizardState, onBack func() screen) screen
 			}
 			return nil
 		}),
+		makeInputField("dotool", "dotool Timeout", "Examples: 5s, 10s.", cfg.DotoolTimeout.String(), "5s", func(s string) error {
+			if _, err := time.ParseDuration(s); err != nil {
+				return fmt.Errorf("invalid duration format")
+			}
+			return nil
+		}),
+		makeInputField("dotool_typedelay", "dotool Typedelay", "Delay between keypresses in milliseconds. Examples: 1ms, 5ms.", cfg.DotoolTypedelay.String(), "1ms", func(s string) error {
+			if _, err := time.ParseDuration(s); err != nil {
+				return fmt.Errorf("invalid duration format")
+			}
+			return nil
+		}),
+		makeInputField("dotool_typehold", "dotool Typehold", "Duration each key is held in milliseconds. Examples: 2ms, 5ms.", cfg.DotoolTypehold.String(), "2ms", func(s string) error {
+			if _, err := time.ParseDuration(s); err != nil {
+				return fmt.Errorf("invalid duration format")
+			}
+			return nil
+		}),
 		makeInputField("clipboard", "Clipboard Timeout", "Examples: 3s, 5s.", cfg.ClipboardTimeout.String(), "3s", func(s string) error {
 			if _, err := time.ParseDuration(s); err != nil {
 				return fmt.Errorf("invalid duration format")
@@ -830,6 +849,9 @@ func newInjectionTimeoutsScreen(state *wizardState, onBack func() screen) screen
 	screen := newFormScreen(state, "Injection Timeouts", nil, fields, func(values map[string]string) screen {
 		state.cfg.Injection.YdotoolTimeout, _ = time.ParseDuration(values["ydotool"])
 		state.cfg.Injection.WtypeTimeout, _ = time.ParseDuration(values["wtype"])
+		state.cfg.Injection.DotoolTimeout, _ = time.ParseDuration(values["dotool"])
+		state.cfg.Injection.DotoolTypedelay, _ = time.ParseDuration(values["dotool_typedelay"])
+		state.cfg.Injection.DotoolTypehold, _ = time.ParseDuration(values["dotool_typehold"])
 		state.cfg.Injection.ClipboardTimeout, _ = time.ParseDuration(values["clipboard"])
 		return onBack()
 	}, onBack)
@@ -1040,7 +1062,7 @@ func formatAdvancedRecordingLabel(cfg *config.Config) string {
 }
 
 func formatAdvancedInjectionTimeoutLabel(cfg *config.Config) string {
-	return fmt.Sprintf("Injection Timeouts (ydotool=%s, wtype=%s, clipboard=%s)", cfg.Injection.YdotoolTimeout, cfg.Injection.WtypeTimeout, cfg.Injection.ClipboardTimeout)
+	return fmt.Sprintf("Injection Timeouts (ydotool=%s, wtype=%s, dotool=%s, clipboard=%s)", cfg.Injection.YdotoolTimeout, cfg.Injection.WtypeTimeout, cfg.Injection.DotoolTimeout, cfg.Injection.ClipboardTimeout)
 }
 
 func getNotificationMessage(cfg *config.Config, def notify.MessageDef) (string, string) {

--- a/internal/tui/flows.go
+++ b/internal/tui/flows.go
@@ -555,7 +555,7 @@ func newKeywordsScreen(state *wizardState, onBack func() screen) screen {
 func newInjectionScreen(state *wizardState, onBack func() screen) screen {
 	selected := state.cfg.Injection.Backends
 	if len(selected) == 0 {
-		selected = []string{"ydotool", "wtype", "clipboard"}
+		selected = []string{"ydotool", "wtype", "dotool", "clipboard"}
 	}
 	selectedSet := make(map[string]bool, len(selected))
 	for _, b := range selected {

--- a/internal/tui/wizard_test.go
+++ b/internal/tui/wizard_test.go
@@ -30,3 +30,40 @@ func TestWizardMenuTransitionAppliesSize(t *testing.T) {
 		t.Fatalf("expected list size to be set, got width=%d height=%d", listScreen.list.Width(), listScreen.list.Height())
 	}
 }
+
+func TestInjectionScreenPreservesConfiguredBackendOrder(t *testing.T) {
+	cfg := &config.Config{
+		Injection: config.InjectionConfig{
+			Backends: []string{"dotool", "wtype", "clipboard"},
+		},
+	}
+	state := &wizardState{cfg: cfg}
+
+	next := newInjectionScreen(state, func() screen { return nil })
+	screen, ok := next.(*multiSelectScreen)
+	if !ok {
+		t.Fatalf("expected multi select screen, got %T", next)
+	}
+	items := listToToggleItems(screen.list.Items())
+
+	wantOrder := []string{"dotool", "wtype", "clipboard", "ydotool"}
+	if len(items) != len(wantOrder) {
+		t.Fatalf("items length = %d, want %d", len(items), len(wantOrder))
+	}
+	for i, want := range wantOrder {
+		if items[i].value != want {
+			t.Fatalf("item %d value = %q, want %q", i, items[i].value, want)
+		}
+	}
+
+	screen.onSubmit(items)
+	wantSaved := []string{"dotool", "wtype", "clipboard"}
+	if len(cfg.Injection.Backends) != len(wantSaved) {
+		t.Fatalf("saved backends length = %d, want %d", len(cfg.Injection.Backends), len(wantSaved))
+	}
+	for i, want := range wantSaved {
+		if cfg.Injection.Backends[i] != want {
+			t.Fatalf("saved backend %d = %q, want %q", i, cfg.Injection.Backends[i], want)
+		}
+	}
+}

--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -19,6 +19,7 @@ optdepends=(
     'hyprland: For Hyprland window manager integration'
     'sway: For Sway window manager integration'
     'ydotool: Alternative text injection backend (recommended for Chromium apps)'
+    'dotool: Text injection via keystroke simulation (requires user in input group)'
 )
 provides=('hyprvoice')
 conflicts=('hyprvoice')


### PR DESCRIPTION
Hi, thanks for creating hyprvoice!

I did not raise an issue for this, as it was easy enough to implement myself, hopefully, that's OK.

## What
This adds [dotool](https://sr.ht/~geb/dotool) backend.
- `dotool` is used in client-daemon setup for absolute minimum latency (no udev initialization on each inject)
- While I have key delay 0ms and key hold 1ms configured for myself, I went a little more conservative with the defaults: 1ms/2ms (the dotool's defaults seem a bit too much: 2ms/8ms, but let's hear users' feedback)

## Why
- ydotool typing is annoyingly slow
- wtype doesn't work on Plasma Wayland
- clipboard is polluting my clipboard history and requires pasting

I did not add any tests, just fixed the ones that started failing after adding dotool, as it would largely be copy-paste.
But if you tell me what to add, I'll try to accomodate :)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `dotool` injection backend that pipes commands to the `dotoold` daemon via `dotoolc` for low-latency keystroke injection on Wayland. The integration is well-structured and follows existing backend patterns, but two P1 issues need to be resolved before merging:

- **Newline injection**: `text` is written verbatim into the dotool command stream; any newline terminates the `type` command and the remainder is parsed as a new dotool command (e.g., `key super`), causing silent misbehavior for multi-line transcription results.
- **Backward-compat breakage**: `DotoolTimeout` is validated unconditionally (`<= 0` → error); existing users upgrading with a config that predates this PR will have `dotool_timeout = 0` (TOML zero-value) and the app will refuse to start even if they never use dotool.

<h3>Confidence Score: 3/5</h3>

Not safe to merge as-is — two P1 issues affect all existing users on upgrade and any multi-line transcription result

Two independent P1 findings: a command-injection via newlines that will silently misbehave on legitimate multi-line voice transcriptions, and a validation regression that breaks every existing config file on upgrade. Both are on the direct changed path.

internal/injection/dotool.go (line 55) and internal/config/validate.go (lines 169-177)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/injection/dotool.go | New dotool backend — newline injection in the type command stream is a P1 logic bug; text must be sanitized before writing to stdin |
| internal/config/validate.go | DotoolTimeout validation is unconditional — breaks every existing config on upgrade because the TOML key is missing (zero value) even when dotool is not in backends |
| internal/injection/injection.go | Clean integration of dotool into the injector — backend registration and timeout dispatch look correct |
| internal/config/defaults.go | dotool added to default backend chain and its defaults (5s timeout, 1ms/2ms delay) look reasonable |
| internal/config/config_test.go | Test fixtures consistently updated with dotool defaults; formatting cleaned up throughout |
| docs/config.md | Documentation clearly covers dotool setup, systemd service, and the typedelay/typehold tuning guidance |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant Injector
    participant DotoolBackend
    participant dotoolc
    participant dotoold

    App->>Injector: Inject(ctx, text)
    Injector->>DotoolBackend: Inject(ctx, text, timeout)
    DotoolBackend->>DotoolBackend: Available() — exec.LookPath("dotoolc")
    DotoolBackend->>dotoolc: exec.CommandContext(ctx, "dotoolc")
    DotoolBackend->>dotoolc: stdin ← "typedelay N\ntypehold N\ntype TEXT\n"
    dotoolc->>dotoold: forward commands over unix socket
    dotoold-->>dotoolc: ack
    dotoolc-->>DotoolBackend: exit 0
    DotoolBackend-->>Injector: nil
    Injector-->>App: nil (success)
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: internal/injection/dotool.go
Line: 55

Comment:
**Newline injection breaks dotool command stream**

The dotool protocol processes one command per line; the `type` command only applies to the rest of that single line. If `text` contains a newline, everything after it is treated as a new dotool command. For example, text `"hello\nkey super"` would emit `type hello` then `key super` — pressing the Super key in addition to typing. Voice transcription can legitimately produce multi-line text, so this will silently misbehave (or inject unintended keystrokes) whenever it does.

Strip or replace newlines before sending:

```go
sanitized := strings.ReplaceAll(text, "\n", " ")
if _, err := fmt.Fprintf(input, "typedelay %v\ntypehold %v\ntype %s\n", c.delayMs, c.holdMs, sanitized); err != nil {
```

Or use `strings.NewReplacer("\n", " ", "\r", " ")` if carriage returns are also possible.

```suggestion
sanitized := strings.ReplaceAll(strings.ReplaceAll(text, "\r\n", " "), "\n", " ")
	if _, err := fmt.Fprintf(input, "typedelay %v\ntypehold %v\ntype %s\n", c.delayMs, c.holdMs, sanitized); err != nil {
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/config/validate.go
Line: 169-177

Comment:
**Unconditional DotoolTimeout validation breaks existing configs on upgrade**

`DotoolTimeout` is always validated (`<= 0` ⇒ error), even when `dotool` is not in the configured backends. Any existing user who upgrades will have `dotool_timeout = 0` (TOML zero-value for a missing key), causing the app to refuse to start with `"invalid injection.dotool_timeout: 0s"` — even if they never use dotool.

The existing ydotool/wtype/clipboard timeouts were there from the beginning, so this is a new breaking change introduced by the PR. Consider guarding these checks on whether `dotool` is actually configured in backends, or coercing the zero value to the default `5s` during config loading.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: internal/injection/dotool.go
Line: 21-31

Comment:
**`Available()` called on every injection**

`Inject()` calls `c.Available()` (which runs `exec.LookPath`) on every invocation. This is minor repeated syscall overhead; the wtype backend does it the same way so it is consistent, but caching the result with a `sync.Once` or checking once during `NewDotoolBackend` would avoid the repeated path lookup in a hot path.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat(backend): add dotool backend"](https://github.com/leonardotrapani/hyprvoice/commit/ecefa7292ef8f7bb9c448c801bc816dd411b6c8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29756836)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->