### PR TITLE
packaging: use graphical-session.target for systemd unit

### DIFF
--- a/packaging/hyprvoice.service
+++ b/packaging/hyprvoice.service
@@ -1,16 +1,15 @@
 [Unit]
 Description=Hyprvoice voice-to-text daemon
 Documentation=https://github.com/leonardotrapani/hyprvoice
-After=pipewire.service
+After=graphical-session.target pipewire.service
+PartOf=graphical-session.target
 Wants=pipewire.service
 
 [Service]
 Type=simple
 ExecStart=/usr/bin/hyprvoice serve
-ExecStartPre=/usr/bin/systemctl --user import-environment WAYLAND_DISPLAY XDG_RUNTIME_DIR
-ExecStartPre=/bin/sh -c 'until [ -n "$WAYLAND_DISPLAY" ]; do sleep 0.1; done'
 Restart=on-failure
 RestartSec=5
 
 [Install]
-WantedBy=default.target
+WantedBy=graphical-session.target


### PR DESCRIPTION
Fixes #37.

The current `ExecStartPre` polls `$WAYLAND_DISPLAY` in a shell that captured an empty env at fork time. The loop can't observe a later change and always hits the 90 s start-pre timeout on KDE Plasma Wayland. Replace with proper `graphical-session.target` ordering and drop both `ExecStartPre` lines.

`PartOf=graphical-session.target` also makes the daemon stop cleanly when the session ends.

Verified on Plasma 6.6.4: cold-start ~95 s to ~2.4 s. Full analysis in #37.