### PR TITLE
Add NVIDIA Parakeet TDT 0.6B V3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ All supported speech-to-text providers and models:
 - English-only: `tiny.en`, `base.en`, `small.en`, `medium.en`
 - Multilingual: `tiny`, `base`, `small`, `medium`, `large-v1`, `large-v2`, `large-v3`, `large-v3-turbo`
 
+### parakeet (local)
+
+- Multilingual (25 European languages): `parakeet-tdt-0.6b-v3`
+- Requires [NeMo-Speech.cpp](https://github.com/NVIDIA/NeMo-Speech.cpp) runtime
+
 ### Deepgram (cloud)
 
 - `flux-general-en`

--- a/cmd/hyprvoice/localmodels.go
+++ b/cmd/hyprvoice/localmodels.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/leonardotrapani/hyprvoice/internal/models/parakeet"
+	"github.com/leonardotrapani/hyprvoice/internal/models/whisper"
+	"github.com/leonardotrapani/hyprvoice/internal/provider"
+)
+
+// localModelInstalled returns true if a local model has been downloaded.
+// AdapterType determines which model registry (and download location) applies.
+func localModelInstalled(m *provider.Model) bool {
+	switch m.AdapterType {
+	case provider.AdapterWhisperCpp:
+		return whisper.IsInstalled(m.ID)
+	case provider.AdapterParakeet:
+		return parakeet.IsInstalled(m.ID)
+	default:
+		return false
+	}
+}
+
+// localModelPath returns the full path of a downloaded local model.
+func localModelPath(m *provider.Model) string {
+	switch m.AdapterType {
+	case provider.AdapterWhisperCpp:
+		return whisper.GetModelPath(m.ID)
+	case provider.AdapterParakeet:
+		return parakeet.GetModelPath(m.ID)
+	default:
+		return ""
+	}
+}
+
+// localModelDownload downloads a local model with progress reporting.
+func localModelDownload(ctx context.Context, m *provider.Model, onProgress func(downloaded, total int64)) error {
+	switch m.AdapterType {
+	case provider.AdapterWhisperCpp:
+		return whisper.Download(ctx, m.ID, onProgress)
+	case provider.AdapterParakeet:
+		return parakeet.Download(ctx, m.ID, onProgress)
+	default:
+		return fmt.Errorf("local download not supported for model: %s", m.ID)
+	}
+}
+
+// localModelRemove removes a downloaded local model.
+func localModelRemove(m *provider.Model) error {
+	switch m.AdapterType {
+	case provider.AdapterWhisperCpp:
+		return whisper.Remove(m.ID)
+	case provider.AdapterParakeet:
+		return parakeet.Remove(m.ID)
+	default:
+		return fmt.Errorf("local removal not supported for model: %s", m.ID)
+	}
+}

--- a/cmd/hyprvoice/main.go
+++ b/cmd/hyprvoice/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/leonardotrapani/hyprvoice/internal/bus"
 	"github.com/leonardotrapani/hyprvoice/internal/config"
 	"github.com/leonardotrapani/hyprvoice/internal/daemon"
-	"github.com/leonardotrapani/hyprvoice/internal/models/whisper"
 	"github.com/leonardotrapani/hyprvoice/internal/provider"
 	"github.com/leonardotrapani/hyprvoice/internal/tui"
 	"github.com/spf13/cobra"
@@ -351,7 +350,7 @@ func runModelList(providerFilter, typeFilter string) error {
 		fmt.Printf("\n%s:\n", providerName)
 
 		for _, m := range models {
-			printModelLine(m)
+			printModelLine(&m)
 		}
 	}
 
@@ -359,11 +358,11 @@ func runModelList(providerFilter, typeFilter string) error {
 	return nil
 }
 
-func printModelLine(m provider.Model) {
+func printModelLine(m *provider.Model) {
 	// build prefix: checkmark for installed local models
 	prefix := "  "
 	if m.Local {
-		if whisper.IsInstalled(m.ID) {
+		if localModelInstalled(m) {
 			prefix = "  [x]"
 		} else {
 			prefix = "  [ ]"
@@ -427,8 +426,8 @@ func runModelDownload(ctx context.Context, modelName string) error {
 	}
 
 	// check if already installed
-	if whisper.IsInstalled(modelName) {
-		path := whisper.GetModelPath(modelName)
+	if localModelInstalled(model) {
+		path := localModelPath(model)
 		fmt.Printf("model '%s' is already installed at %s\n", modelName, path)
 		return nil
 	}
@@ -441,7 +440,7 @@ func runModelDownload(ctx context.Context, modelName string) error {
 	fmt.Println("...")
 
 	var lastPercent int
-	err = whisper.Download(ctx, modelName, func(downloaded, total int64) {
+	err = localModelDownload(ctx, model, func(downloaded, total int64) {
 		if total > 0 {
 			percent := int(downloaded * 100 / total)
 			if percent >= lastPercent+10 {
@@ -454,7 +453,7 @@ func runModelDownload(ctx context.Context, modelName string) error {
 		return fmt.Errorf("download failed: %w", err)
 	}
 
-	path := whisper.GetModelPath(modelName)
+	path := localModelPath(model)
 	fmt.Printf("\ndownload complete: %s\n", path)
 	return nil
 }
@@ -484,12 +483,12 @@ func runModelRemove(modelName string) error {
 	}
 
 	// check if installed
-	if !whisper.IsInstalled(modelName) {
+	if !localModelInstalled(model) {
 		return fmt.Errorf("model '%s' is not installed", modelName)
 	}
 
 	// remove the model
-	if err := whisper.Remove(modelName); err != nil {
+	if err := localModelRemove(model); err != nil {
 		return fmt.Errorf("failed to remove model: %w", err)
 	}
 

--- a/internal/models/parakeet/models.go
+++ b/internal/models/parakeet/models.go
@@ -1,0 +1,98 @@
+package parakeet
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// ModelInfo holds metadata for a parakeet model
+type ModelInfo struct {
+	ID           string   // model identifier (e.g., "parakeet-tdt-0.6b-v3")
+	Name         string   // display name (e.g., "Parakeet TDT 0.6B V3")
+	Filename     string   // file name (e.g., "parakeet-tdt-0.6b-v3.q8_0.gguf")
+	Size         string   // human readable size
+	SizeBytes    int64    // size in bytes for progress tracking
+	Languages    []string // supported language codes ("" = auto-detect)
+	DocsURL      string   // model documentation URL
+	DownloadURL  string   // full download URL
+	NeedsRuntime bool     // requires nemo-speech runtime
+}
+
+// available parakeet models from huggingface.co/nvidia/parakeet-tdt-0.6b-v3
+// https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
+const (
+	baseDownloadURL = "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3/resolve/main"
+	docsURL         = "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3"
+)
+
+// parakeet-tdt-0.6b-v3 supports 25 European languages with auto language detection
+var europeanLanguages = []string{
+	"en", "es", "fr", "de", "bg", "hr", "cs", "da", "nl", "et",
+	"fi", "el", "hu", "it", "lv", "lt", "mt", "pl", "pt", "ro",
+	"sk", "sl", "sv", "ru", "uk",
+}
+
+var models = []ModelInfo{
+	{
+		ID:           "parakeet-tdt-0.6b-v3",
+		Name:         "Parakeet TDT 0.6B V3",
+		Filename:     "parakeet-tdt-0.6b-v3.q8_0.gguf",
+		Size:         "714MB",
+		SizeBytes:    713_975_456,
+		Languages:    europeanLanguages,
+		DocsURL:      docsURL,
+		DownloadURL:  baseDownloadURL + "/parakeet-tdt-0.6b-v3.q8_0.gguf",
+		NeedsRuntime: true,
+	},
+}
+
+// modelByID maps model ID to ModelInfo for quick lookup
+var modelByID = func() map[string]ModelInfo {
+	m := make(map[string]ModelInfo, len(models))
+	for _, model := range models {
+		m[model.ID] = model
+	}
+	return m
+}()
+
+// GetModelsDir returns the directory where parakeet models are stored.
+// Creates the directory if it doesn't exist.
+func GetModelsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(home, ".local", "share", "hyprvoice", "models", "parakeet")
+	return dir, nil
+}
+
+// GetModelPath returns the full path to a model file.
+// Returns empty string if model ID is unknown.
+func GetModelPath(modelID string) string {
+	info, ok := modelByID[modelID]
+	if !ok {
+		return ""
+	}
+	dir, err := GetModelsDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, info.Filename)
+}
+
+// GetModel returns info for a model by ID.
+// Returns nil if model ID is unknown.
+func GetModel(modelID string) *ModelInfo {
+	info, ok := modelByID[modelID]
+	if !ok {
+		return nil
+	}
+	return &info
+}
+
+// ListModels returns all available parakeet models
+func ListModels() []ModelInfo {
+	result := make([]ModelInfo, len(models))
+	copy(result, models)
+	return result
+}

--- a/internal/models/parakeet/registry.go
+++ b/internal/models/parakeet/registry.go
@@ -1,0 +1,159 @@
+package parakeet
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// ProgressFunc is called during download with bytes downloaded and total
+type ProgressFunc func(downloaded, total int64)
+
+// IsInstalled returns true if the model is downloaded and available
+func IsInstalled(modelID string) bool {
+	path := GetModelPath(modelID)
+	if path == "" {
+		return false
+	}
+	info, err := os.Stat(path)
+	return err == nil && info.Size() > 0
+}
+
+// ListInstalled returns IDs of all installed models
+func ListInstalled() []string {
+	var installed []string
+	for _, m := range models {
+		if IsInstalled(m.ID) {
+			installed = append(installed, m.ID)
+		}
+	}
+	return installed
+}
+
+// Download downloads a model from huggingface.
+// Progress callback is optional (can be nil).
+// Uses context for cancellation.
+func Download(ctx context.Context, modelID string, onProgress ProgressFunc) error {
+	info := GetModel(modelID)
+	if info == nil {
+		return fmt.Errorf("unknown model: %s", modelID)
+	}
+
+	// ensure directory exists
+	dir, err := GetModelsDir()
+	if err != nil {
+		return fmt.Errorf("failed to get models directory: %w", err)
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create models directory: %w", err)
+	}
+
+	destPath := filepath.Join(dir, info.Filename)
+	tempPath := destPath + ".downloading"
+
+	// create temp file
+	out, err := os.Create(tempPath)
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	defer func() {
+		out.Close()
+		os.Remove(tempPath) // clean up temp file on error
+	}()
+
+	// create request with context
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, info.DownloadURL, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to download: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("download failed with status: %s", resp.Status)
+	}
+
+	total := resp.ContentLength
+	if total < 0 {
+		total = info.SizeBytes // fall back to expected size
+	}
+
+	var downloaded int64
+	buf := make([]byte, 32*1024) // 32KB buffer
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		n, err := resp.Body.Read(buf)
+		if n > 0 {
+			_, writeErr := out.Write(buf[:n])
+			if writeErr != nil {
+				return fmt.Errorf("failed to write: %w", writeErr)
+			}
+			downloaded += int64(n)
+			if onProgress != nil {
+				onProgress(downloaded, total)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to read: %w", err)
+		}
+	}
+
+	// close file before rename
+	if err := out.Close(); err != nil {
+		return fmt.Errorf("failed to close file: %w", err)
+	}
+
+	// rename temp file to final destination
+	if err := os.Rename(tempPath, destPath); err != nil {
+		return fmt.Errorf("failed to finalize download: %w", err)
+	}
+
+	return nil
+}
+
+// Remove deletes a downloaded model
+func Remove(modelID string) error {
+	info := GetModel(modelID)
+	if info == nil {
+		return fmt.Errorf("unknown model: %s", modelID)
+	}
+
+	path := GetModelPath(modelID)
+	if path == "" {
+		return fmt.Errorf("failed to get model path")
+	}
+
+	if !IsInstalled(modelID) {
+		return fmt.Errorf("model not installed: %s", modelID)
+	}
+
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("failed to remove model: %w", err)
+	}
+
+	return nil
+}
+
+// GetInstalledPath returns the path to an installed model, or error if not installed
+func GetInstalledPath(modelID string) (string, error) {
+	if !IsInstalled(modelID) {
+		return "", fmt.Errorf("model not installed: %s", modelID)
+	}
+	return GetModelPath(modelID), nil
+}

--- a/internal/provider/names.go
+++ b/internal/provider/names.go
@@ -8,6 +8,7 @@ const (
 	ProviderElevenLabs = "elevenlabs"
 	ProviderDeepgram   = "deepgram"
 	ProviderWhisperCpp = "whisper-cpp"
+	ProviderParakeet   = "parakeet"
 )
 
 // Config provider names (used in config file transcription.provider)
@@ -18,6 +19,7 @@ const (
 	ConfigProviderElevenLabs           = "elevenlabs"
 	ConfigProviderDeepgram             = "deepgram"
 	ConfigProviderWhisperCpp           = "whisper-cpp"
+	ConfigProviderParakeet             = "parakeet"
 )
 
 // Environment variable names for API keys
@@ -36,6 +38,7 @@ const (
 	AdapterElevenLabsStream = "elevenlabs-streaming"
 	AdapterDeepgram         = "deepgram"
 	AdapterWhisperCpp       = "whisper-cpp"
+	AdapterParakeet         = "parakeet"
 	AdapterOpenAIRealtime   = "openai-realtime"
 )
 

--- a/internal/provider/parakeet.go
+++ b/internal/provider/parakeet.go
@@ -1,0 +1,66 @@
+package provider
+
+import "github.com/leonardotrapani/hyprvoice/internal/models/parakeet"
+
+// ParakeetProvider implements Provider for local NVIDIA Parakeet transcription
+// via the NeMo-Speech.cpp runtime (nemo-speech CLI).
+type ParakeetProvider struct{}
+
+func (p *ParakeetProvider) Name() string {
+	return ProviderParakeet
+}
+
+func (p *ParakeetProvider) RequiresAPIKey() bool {
+	return false
+}
+
+func (p *ParakeetProvider) ValidateAPIKey(key string) bool {
+	return true // no API key needed
+}
+
+func (p *ParakeetProvider) APIKeyURL() string {
+	return ""
+}
+
+func (p *ParakeetProvider) IsLocal() bool {
+	return true
+}
+
+func (p *ParakeetProvider) Models() []Model {
+	// https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3
+	docsURL := "https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3"
+
+	parakeetModels := parakeet.ListModels()
+	result := make([]Model, 0, len(parakeetModels))
+
+	for _, pm := range parakeetModels {
+		result = append(result, Model{
+			ID:                 pm.ID,
+			Name:               pm.Name,
+			Description:        "Free/offline; NVIDIA Parakeet TDT, high accuracy, auto language detection (NeMo-Speech.cpp)",
+			Type:               Transcription,
+			SupportsBatch:      true,
+			SupportsStreaming:  false,
+			Local:              true,
+			AdapterType:        AdapterParakeet,
+			SupportedLanguages: pm.Languages,
+			Endpoint:           nil, // local CLI, no HTTP endpoint
+			LocalInfo: &LocalModelInfo{
+				Filename:    pm.Filename,
+				Size:        pm.Size,
+				DownloadURL: pm.DownloadURL,
+			},
+			DocsURL: docsURL,
+		})
+	}
+
+	return result
+}
+
+func (p *ParakeetProvider) DefaultModel(t ModelType) string {
+	switch t {
+	case Transcription:
+		return "parakeet-tdt-0.6b-v3"
+	}
+	return ""
+}

--- a/internal/provider/parakeet_test.go
+++ b/internal/provider/parakeet_test.go
@@ -1,0 +1,90 @@
+package provider
+
+import "testing"
+
+func TestParakeetProvider_GetProvider(t *testing.T) {
+	p := GetProvider("parakeet")
+	if p == nil {
+		t.Fatal("GetProvider('parakeet') returned nil")
+	}
+	if p.Name() != "parakeet" {
+		t.Errorf("expected name 'parakeet', got '%s'", p.Name())
+	}
+}
+
+func TestParakeetProvider_Models(t *testing.T) {
+	p := &ParakeetProvider{}
+	models := p.Models()
+
+	if len(models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(models))
+	}
+
+	for _, m := range models {
+		if m.ID != "parakeet-tdt-0.6b-v3" {
+			t.Errorf("expected model ID 'parakeet-tdt-0.6b-v3', got '%s'", m.ID)
+		}
+		if !m.Local {
+			t.Errorf("model %s: expected Local=true", m.ID)
+		}
+		if m.LocalInfo == nil {
+			t.Errorf("model %s: expected LocalInfo to be set", m.ID)
+		}
+		if m.AdapterType != "parakeet" {
+			t.Errorf("model %s: expected AdapterType='parakeet', got '%s'", m.ID, m.AdapterType)
+		}
+		if m.Type != Transcription {
+			t.Errorf("model %s: expected Type=Transcription", m.ID)
+		}
+		if m.Endpoint != nil {
+			t.Errorf("model %s: expected Endpoint=nil for local model", m.ID)
+		}
+		if m.LocalInfo.Filename == "" || m.LocalInfo.Size == "" || m.LocalInfo.DownloadURL == "" {
+			t.Errorf("model %s: LocalInfo fields should not be empty", m.ID)
+		}
+		if !m.NeedsDownload() {
+			t.Errorf("model %s: NeedsDownload() should be true for local model", m.ID)
+		}
+	}
+}
+
+func TestParakeetProvider_LanguageSupport(t *testing.T) {
+	p := &ParakeetProvider{}
+	m := p.Models()[0]
+
+	for _, lang := range []string{"en", "es", "fr", "de", "it", "pl", "ru"} {
+		if !m.SupportsLanguage(lang) {
+			t.Errorf("model %s: SupportsLanguage(%q) should be true", m.ID, lang)
+		}
+	}
+	if !m.SupportsLanguage("") {
+		t.Errorf("model %s: SupportsLanguage('') should be true (auto always supported)", m.ID)
+	}
+	if m.SupportsLanguage("ja") {
+		t.Errorf("model %s: SupportsLanguage('ja') should be false (not a European language)", m.ID)
+	}
+}
+
+func TestParakeetProvider_RequiresAPIKey(t *testing.T) {
+	p := &ParakeetProvider{}
+	if p.RequiresAPIKey() {
+		t.Error("RequiresAPIKey() should return false")
+	}
+}
+
+func TestParakeetProvider_IsLocal(t *testing.T) {
+	p := &ParakeetProvider{}
+	if !p.IsLocal() {
+		t.Error("IsLocal() should return true")
+	}
+}
+
+func TestParakeetProvider_DefaultModel(t *testing.T) {
+	p := &ParakeetProvider{}
+	if p.DefaultModel(Transcription) != "parakeet-tdt-0.6b-v3" {
+		t.Errorf("expected DefaultModel(Transcription)='parakeet-tdt-0.6b-v3', got '%s'", p.DefaultModel(Transcription))
+	}
+	if p.DefaultModel(LLM) != "" {
+		t.Errorf("expected DefaultModel(LLM)='', got '%s'", p.DefaultModel(LLM))
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -30,6 +30,7 @@ func init() {
 	Register(&MistralProvider{})
 	Register(&ElevenLabsProvider{})
 	Register(&WhisperCppProvider{})
+	Register(&ParakeetProvider{})
 	Register(&DeepgramProvider{})
 }
 

--- a/internal/transcriber/adapter_parakeet.go
+++ b/internal/transcriber/adapter_parakeet.go
@@ -1,0 +1,92 @@
+package transcriber
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ParakeetAdapter implements BatchAdapter for local NVIDIA Parakeet transcription
+// via the NeMo-Speech.cpp runtime (nemo-speech CLI).
+type ParakeetAdapter struct {
+	modelPath string
+	device    string
+}
+
+// NewParakeetAdapter creates a new parakeet adapter
+// modelPath: full path to the model file (e.g., ~/.local/share/hyprvoice/models/parakeet/parakeet-tdt-0.6b-v3.q8_0.gguf)
+// device: inference device ("" for auto, "cpu", "cuda:0", "vulkan:0")
+func NewParakeetAdapter(modelPath, device string) *ParakeetAdapter {
+	return &ParakeetAdapter{
+		modelPath: modelPath,
+		device:    device,
+	}
+}
+
+func (a *ParakeetAdapter) Transcribe(ctx context.Context, audioData []byte) (string, error) {
+	if len(audioData) == 0 {
+		return "", nil
+	}
+
+	// check model file exists
+	if _, err := os.Stat(a.modelPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("model file not found: %s (run 'hyprvoice model download parakeet-tdt-0.6b-v3')", a.modelPath)
+	}
+
+	// check nemo-speech exists
+	speechPath, err := exec.LookPath("nemo-speech")
+	if err != nil {
+		return "", fmt.Errorf("nemo-speech not found: install NeMo-Speech.cpp (see https://github.com/NVIDIA/NeMo-Speech.cpp)")
+	}
+
+	// convert raw PCM to WAV
+	wavData, err := convertToWAV(audioData)
+	if err != nil {
+		return "", fmt.Errorf("convert to WAV: %w", err)
+	}
+
+	// write to temp file
+	tmpDir := os.TempDir()
+	tmpFile := filepath.Join(tmpDir, fmt.Sprintf("hyprvoice-parakeet-%d.wav", time.Now().UnixNano()))
+	if err := os.WriteFile(tmpFile, wavData, 0600); err != nil {
+		return "", fmt.Errorf("write temp file: %w", err)
+	}
+	defer os.Remove(tmpFile)
+
+	// build command args
+	args := []string{"transcribe", tmpFile, "--model", a.modelPath, "--quiet"}
+	if a.device != "" {
+		args = append(args, "--device", a.device)
+	}
+
+	// execute nemo-speech
+	cmd := exec.CommandContext(ctx, speechPath, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err = cmd.Run()
+	duration := time.Since(start)
+
+	if err != nil {
+		// check if context was cancelled
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		log.Printf("parakeet: command failed after %v: %v\nstderr: %s", duration, err, stderr.String())
+		return "", fmt.Errorf("nemo-speech failed: %w", err)
+	}
+
+	// parse output - nemo-speech writes plain transcription text to stdout
+	text := strings.TrimSpace(stdout.String())
+
+	log.Printf("parakeet: transcribed %d bytes in %v: %q", len(audioData), duration, text)
+	return text, nil
+}

--- a/internal/transcriber/adapter_parakeet_test.go
+++ b/internal/transcriber/adapter_parakeet_test.go
@@ -1,0 +1,75 @@
+package transcriber
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestParakeetAdapter_ImplementsBatchAdapter(t *testing.T) {
+	// compile-time check that ParakeetAdapter implements BatchAdapter
+	var _ BatchAdapter = (*ParakeetAdapter)(nil)
+}
+
+func TestParakeetAdapter_EmptyAudio(t *testing.T) {
+	adapter := NewParakeetAdapter("/nonexistent/model.bin", "")
+	text, err := adapter.Transcribe(context.Background(), []byte{})
+	if err != nil {
+		t.Errorf("expected no error for empty audio, got: %v", err)
+	}
+	if text != "" {
+		t.Errorf("expected empty text for empty audio, got: %q", text)
+	}
+}
+
+func TestParakeetAdapter_MissingModel(t *testing.T) {
+	adapter := NewParakeetAdapter("/nonexistent/path/model.bin", "")
+
+	// create minimal valid PCM data (just zeros)
+	audioData := make([]byte, 32000) // 1 second at 16kHz 16-bit
+
+	_, err := adapter.Transcribe(context.Background(), audioData)
+	if err == nil {
+		t.Error("expected error for missing model file")
+	}
+	if err != nil && !contains(err.Error(), "model file not found") {
+		t.Errorf("expected 'model file not found' error, got: %v", err)
+	}
+}
+
+func TestParakeetAdapter_MissingCli(t *testing.T) {
+	if _, err := exec.LookPath("nemo-speech"); err == nil {
+		t.Skip("nemo-speech is installed")
+	}
+
+	tmpDir := t.TempDir()
+	modelPath := filepath.Join(tmpDir, "model.gguf")
+	if err := os.WriteFile(modelPath, []byte("fake"), 0600); err != nil {
+		t.Fatalf("failed to create model: %v", err)
+	}
+
+	adapter := NewParakeetAdapter(modelPath, "")
+	audioData := make([]byte, 32000)
+
+	_, err := adapter.Transcribe(context.Background(), audioData)
+	if err == nil {
+		t.Error("expected error for missing nemo-speech")
+	}
+	if err != nil && !contains(err.Error(), "nemo-speech not found") {
+		t.Errorf("expected 'nemo-speech not found' error, got: %v", err)
+	}
+}
+
+func TestParakeetAdapter_DeviceConfig(t *testing.T) {
+	adapter := NewParakeetAdapter("/fake/model.bin", "")
+	if adapter.device != "" {
+		t.Errorf("expected empty device (auto), got: %q", adapter.device)
+	}
+
+	adapter = NewParakeetAdapter("/fake/model.bin", "cpu")
+	if adapter.device != "cpu" {
+		t.Errorf("expected 'cpu' device, got: %q", adapter.device)
+	}
+}

--- a/internal/transcriber/transcriber.go
+++ b/internal/transcriber/transcriber.go
@@ -7,6 +7,7 @@ import (
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 
+	"github.com/leonardotrapani/hyprvoice/internal/models/parakeet"
 	"github.com/leonardotrapani/hyprvoice/internal/models/whisper"
 	"github.com/leonardotrapani/hyprvoice/internal/provider"
 	"github.com/leonardotrapani/hyprvoice/internal/recording"
@@ -132,6 +133,12 @@ func NewTranscriber(config Config) (Transcriber, error) {
 			return nil, fmt.Errorf("unknown whisper model: %s", config.Model)
 		}
 		adapter = NewWhisperCppAdapter(modelPath, config.Language, config.Threads)
+	case provider.AdapterParakeet:
+		modelPath := parakeet.GetModelPath(config.Model)
+		if modelPath == "" {
+			return nil, fmt.Errorf("unknown parakeet model: %s", config.Model)
+		}
+		adapter = NewParakeetAdapter(modelPath, "")
 	default:
 		return nil, fmt.Errorf("unsupported adapter type: %s", model.AdapterType)
 	}


### PR DESCRIPTION
Add parakeet as a new local speech-to-text provider using the NeMo-Speech.cpp runtime (nemo-speech CLI).

Changes:
- Add internal/models/parakeet package (model registry + download)
- Add internal/provider/parakeet provider (local, no API key needed)
- Add internal/transcriber/adapter_parakeet (shells out to nemo-speech)
- Add cmd/hyprvoice/localmodels.go to dispatch model ops by provider
- Update transcriber.go to route parakeet adapter
- Update main.go model download/list/remove to handle parakeet
- Add README section for parakeet provider
- Add provider and adapter tests

Model: nvidia/parakeet-tdt-0.6b-v3 (714MB GGUF)
Runtime: NeMo-Speech.cpp (nemo-speech CLI)
Languages: 25 European languages with auto-detection
Download: huggingface.co/nvidia/parakeet-tdt-0.6b-v3