### PR TITLE
fix: send keyterm for Deepgram nova-3/flux instead of dropping keywords

### DIFF
--- a/internal/transcriber/adapter_deepgram.go
+++ b/internal/transcriber/adapter_deepgram.go
@@ -236,13 +236,29 @@ func (a *DeepgramAdapter) buildURL() (string, error) {
 		q.Set("language", lang)
 	}
 
-	// nova-3 uses "keyterm" (singular), others use "keywords" (plural)
-	if len(a.keywords) > 0 && !strings.HasPrefix(a.model, "nova-3") && !strings.HasPrefix(a.model, "flux") {
-		q.Set("keywords", strings.Join(a.keywords, ","))
-	}
+	addDeepgramKeywords(q, a.model, a.keywords)
 
 	u.RawQuery = q.Encode()
 	return u.String(), nil
+}
+
+// addDeepgramKeywords adds vocabulary boosting query parameters for the given model.
+// nova-3 and flux use "keyterm" (Keyterm Prompting), older models use "keywords".
+// Both are repeated once per term, never comma-joined; multi-word phrases are a
+// single value. Whitespace is trimmed and empty terms are skipped.
+// See https://developers.deepgram.com/docs/keyterm and /docs/keywords.
+func addDeepgramKeywords(q url.Values, model string, keywords []string) {
+	param := "keywords"
+	if strings.HasPrefix(model, "nova-3") || strings.HasPrefix(model, "flux") {
+		param = "keyterm"
+	}
+	for _, kw := range keywords {
+		kw = strings.TrimSpace(kw)
+		if kw == "" {
+			continue
+		}
+		q.Add(param, kw)
+	}
 }
 
 // readLoop reads messages from the WebSocket and sends results to the channel

--- a/internal/transcriber/adapter_deepgram_batch.go
+++ b/internal/transcriber/adapter_deepgram_batch.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/leonardotrapani/hyprvoice/internal/provider"
 )
@@ -133,10 +132,7 @@ func (a *DeepgramBatchAdapter) buildURL() (string, error) {
 		q.Set("language", lang)
 	}
 
-	// nova-3 uses "keyterm" (singular), others use "keywords" (plural)
-	if len(a.keywords) > 0 && !strings.HasPrefix(a.model, "nova-3") && !strings.HasPrefix(a.model, "flux") {
-		q.Set("keywords", strings.Join(a.keywords, ","))
-	}
+	addDeepgramKeywords(q, a.model, a.keywords)
 
 	u.RawQuery = q.Encode()
 	return u.String(), nil

--- a/internal/transcriber/adapter_deepgram_test.go
+++ b/internal/transcriber/adapter_deepgram_test.go
@@ -88,6 +88,105 @@ func TestDeepgramAdapter_BuildURL(t *testing.T) {
 	}
 }
 
+func TestDeepgramAdapter_BuildURL_Keywords(t *testing.T) {
+	tests := []struct {
+		name     string
+		model    string
+		keywords []string
+		wantURL  []string // URL must contain all these substrings
+		wantNot  []string // URL must not contain any of these substrings
+	}{
+		{
+			name:     "nova-3 uses repeated keyterm",
+			model:    "nova-3",
+			keywords: []string{"hyprvoice", "wayland"},
+			wantURL:  []string{"keyterm=hyprvoice", "keyterm=wayland"},
+			wantNot:  []string{"keywords="},
+		},
+		{
+			name:     "flux uses repeated keyterm",
+			model:    "flux-general-en",
+			keywords: []string{"hyprvoice", "wayland"},
+			wantURL:  []string{"keyterm=hyprvoice", "keyterm=wayland"},
+			wantNot:  []string{"keywords="},
+		},
+		{
+			name:     "nova-2 uses repeated keywords",
+			model:    "nova-2",
+			keywords: []string{"hyprvoice", "wayland"},
+			wantURL:  []string{"keywords=hyprvoice", "keywords=wayland"},
+			wantNot:  []string{"keyterm=", "hyprvoice%2Cwayland"},
+		},
+		{
+			name:     "multi-word phrase is a single encoded value",
+			model:    "nova-3",
+			keywords: []string{"Leonardo Trapani"},
+			wantURL:  []string{"keyterm=Leonardo+Trapani"},
+		},
+		{
+			name:     "whitespace trimmed and empty terms skipped",
+			model:    "nova-3",
+			keywords: []string{"  hyprvoice ", "", "   "},
+			wantURL:  []string{"keyterm=hyprvoice"},
+			wantNot:  []string{"keyterm=&", "keyterm=+"},
+		},
+		{
+			name:     "no keywords emits no params",
+			model:    "nova-3",
+			keywords: nil,
+			wantNot:  []string{"keyterm=", "keywords="},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := &provider.EndpointConfig{
+				BaseURL: "wss://api.deepgram.com",
+				Path:    "/v1/listen",
+			}
+			adapter := NewDeepgramAdapter(endpoint, "test-key", tt.model, "en", tt.keywords)
+
+			url, err := adapter.buildURL()
+			if err != nil {
+				t.Fatalf("buildURL() error = %v", err)
+			}
+
+			for _, want := range tt.wantURL {
+				if !strings.Contains(url, want) {
+					t.Errorf("buildURL() = %q, want to contain %q", url, want)
+				}
+			}
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(url, notWant) {
+					t.Errorf("buildURL() = %q, must not contain %q", url, notWant)
+				}
+			}
+
+			// batch adapter shares the same keyword logic
+			batch := NewDeepgramBatchAdapter(&provider.EndpointConfig{
+				BaseURL: "https://api.deepgram.com",
+				Path:    "/v1/listen",
+			}, "test-key", tt.model, "en", tt.keywords)
+
+			batchURL, err := batch.buildURL()
+			if err != nil {
+				t.Fatalf("batch buildURL() error = %v", err)
+			}
+
+			for _, want := range tt.wantURL {
+				if !strings.Contains(batchURL, want) {
+					t.Errorf("batch buildURL() = %q, want to contain %q", batchURL, want)
+				}
+			}
+			for _, notWant := range tt.wantNot {
+				if strings.Contains(batchURL, notWant) {
+					t.Errorf("batch buildURL() = %q, must not contain %q", batchURL, notWant)
+				}
+			}
+		})
+	}
+}
+
 func TestDeepgramAdapter_SendChunkNotStarted(t *testing.T) {
 	endpoint := &provider.EndpointConfig{
 		BaseURL: "wss://api.deepgram.com",


### PR DESCRIPTION
Configured `keywords` were silently dropped on Deepgram `nova-3`/`flux` (the `keyterm` branch the comment describes was never written), and comma-joined on `nova-2`, which Deepgram treats as one literal keyword.

Both URL builders now emit one query param per term — [`keyterm`](https://developers.deepgram.com/docs/keyterm) for nova-3/flux, [`keywords`](https://developers.deepgram.com/docs/keywords) otherwise — via a shared helper, with table tests for both adapters.

Verified live on nova-3 with ~40 domain terms.
